### PR TITLE
fix: handle polymorphic aggregated_by field in DevicePortTable

### DIFF
--- a/unifi/device.go
+++ b/unifi/device.go
@@ -87,7 +87,7 @@ type DevicePortTable struct {
 	StormctrlUcastRate  int64                `json:"stormctrl_ucast_rate,omitempty"`
 	TaggedVlanMgmt      string               `json:"tagged_vlan_mgmt,omitempty"`
 	Masked              bool                 `json:"masked,omitempty"`
-	AggregatedBy        bool                 `json:"aggregated_by,omitempty"`
+	AggregatedBy        interface{}          `json:"aggregated_by,omitempty"`
 }
 
 func (dst *DevicePortTable) UnmarshalJSON(b []byte) error {

--- a/unifi/device_test.go
+++ b/unifi/device_test.go
@@ -1,0 +1,92 @@
+package unifi_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/ubiquiti-community/go-unifi/unifi"
+)
+
+// TestDevicePortTable_AggregatedBy verifies that the aggregated_by field
+// handles polymorphic JSON values from the UniFi API.
+//
+// The API returns aggregated_by as:
+//   - false (boolean): port not in LAG, or is LAG master
+//   - integer: LAG member port, value is the master port number
+func TestDevicePortTable_AggregatedBy(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantVal interface{}
+	}{
+		{"bool false", `{"aggregated_by": false}`, false},
+		{"bool true", `{"aggregated_by": true}`, true},
+		{"integer", `{"aggregated_by": 15}`, float64(15)},
+		{"zero", `{"aggregated_by": 0}`, float64(0)},
+		{"omitted", `{}`, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var dpt unifi.DevicePortTable
+			if err := json.Unmarshal([]byte(tt.input), &dpt); err != nil {
+				t.Fatalf("unmarshal failed: %v", err)
+			}
+			assertAggregatedBy(t, dpt.AggregatedBy, tt.wantVal)
+		})
+	}
+}
+
+// TestDevicePortTable_AggregatedBy_LAGScenarios tests realistic LAG configurations.
+func TestDevicePortTable_AggregatedBy_LAGScenarios(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantVal interface{}
+	}{
+		{
+			name: "LAG member port",
+			input: `{
+				"media": "SFP+",
+				"op_mode": "aggregate",
+				"aggregated_by": 26
+			}`,
+			wantVal: float64(26),
+		},
+		{
+			name: "LAG master port",
+			input: `{
+				"media": "SFP+",
+				"op_mode": "aggregate",
+				"aggregated_by": false
+			}`,
+			wantVal: false,
+		},
+		{
+			name: "regular port",
+			input: `{
+				"media": "GE",
+				"op_mode": "switch",
+				"aggregated_by": false
+			}`,
+			wantVal: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var dpt unifi.DevicePortTable
+			if err := json.Unmarshal([]byte(tt.input), &dpt); err != nil {
+				t.Fatalf("unmarshal failed: %v", err)
+			}
+			assertAggregatedBy(t, dpt.AggregatedBy, tt.wantVal)
+		})
+	}
+}
+
+func assertAggregatedBy(t *testing.T, got, want interface{}) {
+	t.Helper()
+	if got != want {
+		t.Errorf("AggregatedBy = %v (%T), want %v (%T)", got, got, want, want)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the `aggregated_by` field in `DevicePortTable` to handle polymorphic JSON values from the UniFi API.

The UniFi API returns `aggregated_by` as:
- `false` (boolean): when the port is NOT part of a LAG, or is the LAG master
- `integer`: when the port IS aggregated, the value is the master port number

## Problem

Previously, `aggregated_by` was typed as `bool`, causing unmarshalling failures when the API returned an integer for LAG member ports:

```
json: cannot unmarshal number into Go struct field .Alias.aggregated_by of type bool
```

This error occurred when reading devices with Link Aggregation Groups (LAGs) configured, making it impossible to manage UniFi switches with LAG ports via the terraform provider.

## Solution

Changed the type of `AggregatedBy` from `bool` to `interface{}` to accept both boolean and numeric values.

```go
// Before
AggregatedBy        bool                 `json:"aggregated_by,omitempty"`

// After
AggregatedBy        interface{}          `json:"aggregated_by,omitempty"`
```

## Testing

Added table-driven tests in `unifi/device_test.go`:
- `TestDevicePortTable_AggregatedBy`: Tests all value types (bool false, bool true, integer, zero, omitted)
- `TestDevicePortTable_AggregatedBy_LAGScenarios`: Tests realistic LAG configurations (member port, master port, regular port)

```
=== RUN   TestDevicePortTable_AggregatedBy
--- PASS: TestDevicePortTable_AggregatedBy (0.00s)
=== RUN   TestDevicePortTable_AggregatedBy_LAGScenarios
--- PASS: TestDevicePortTable_AggregatedBy_LAGScenarios (0.00s)
```

## Related Issues

- Similar type mismatch bugs have been reported and fixed in related projects:
  - [unpoller/unifi#9](https://github.com/unpoller/unifi/issues/9) - Same error, fixed with FlexBool type
  - [paultyng/terraform-provider-unifi#136](https://github.com/paultyng/terraform-provider-unifi/issues/136) - Similar unmarshalling issues