### PR TITLE
Fix AggregatedBy field type to handle number or false

### DIFF
--- a/unifi/device.go
+++ b/unifi/device.go
@@ -87,7 +87,7 @@ type DevicePortTable struct {
 	StormctrlUcastRate  int64                `json:"stormctrl_ucast_rate,omitempty"`
 	TaggedVlanMgmt      string               `json:"tagged_vlan_mgmt,omitempty"`
 	Masked              bool                 `json:"masked,omitempty"`
-	AggregatedBy        bool                 `json:"aggregated_by,omitempty"`
+	AggregatedBy        types.NumberOrFalse  `json:"aggregated_by,omitempty"`
 }
 
 func (dst *DevicePortTable) UnmarshalJSON(b []byte) error {

--- a/unifi/types/number_or_false.go
+++ b/unifi/types/number_or_false.go
@@ -1,0 +1,59 @@
+package types
+
+import (
+	"encoding/json"
+)
+
+// NumberOrFalse handles fields that can be either `false` (boolean) or a number.
+// For example, `aggregated_by` is `false` when not aggregated, or a port index when aggregated.
+// The value is stored as int64: 0 for false/not set, >0 for the actual number.
+type NumberOrFalse int64
+
+func (n *NumberOrFalse) UnmarshalJSON(b []byte) error {
+	if len(b) == 0 {
+		*n = 0
+		return nil
+	}
+
+	s := string(b)
+
+	// Handle boolean false
+	if s == "false" {
+		*n = 0
+		return nil
+	}
+
+	// Handle boolean true (shouldn't happen but be safe)
+	if s == "true" {
+		*n = 1
+		return nil
+	}
+
+	// Try to parse as number
+	var num int64
+	if err := json.Unmarshal(b, &num); err != nil {
+		// If it fails, default to 0
+		*n = 0
+		return nil
+	}
+
+	*n = NumberOrFalse(num)
+	return nil
+}
+
+func (n NumberOrFalse) MarshalJSON() ([]byte, error) {
+	if n == 0 {
+		return []byte("false"), nil
+	}
+	return json.Marshal(int64(n))
+}
+
+// Int64 returns the value as int64.
+func (n NumberOrFalse) Int64() int64 {
+	return int64(n)
+}
+
+// Bool returns true if the value is non-zero.
+func (n NumberOrFalse) Bool() bool {
+	return n != 0
+}


### PR DESCRIPTION
## Summary

The UniFi API returns `aggregated_by` as either `false` (when a port is not aggregated) or a port index number (when aggregated). This caused JSON unmarshal errors when the field was typed as `bool` and received a number.

## Changes

- Add `types.NumberOrFalse` custom type that properly handles both cases:
  - Unmarshals `false` to 0
  - Unmarshals numbers to their int64 value
  - Marshals 0 back to `false`
  - Marshals non-zero values as numbers
- Update `DevicePortTable.AggregatedBy` to use `types.NumberOrFalse` instead of `bool`

## Testing

Tested against UDM SE running UniFi Network 10.1.83 where this issue was encountered.