### PR TITLE
Handle empty data array response on UDM SE API updates

### DIFF
--- a/cmd/fields/api.go.tmpl
+++ b/cmd/fields/api.go.tmpl
@@ -322,6 +322,12 @@ func (c *ApiClient) update{{ .StructName }}(
 {{ if .IsV2 }}
 	return &respBody, nil
 {{- else }}
+	// UDM SE API returns empty data array on successful PUT.
+	// In that case, fetch the updated resource via GET.
+	if len(respBody.Data) == 0 {
+		return c.get{{ .StructName }}(ctx, site, d.ID)
+	}
+
 	if len(respBody.Data) != 1 {
 		return nil, &NotFoundError{}
 	}

--- a/unifi/account.generated.go
+++ b/unifi/account.generated.go
@@ -180,6 +180,12 @@ func (c *ApiClient) updateAccount(
 		return nil, err
 	}
 
+	// UDM SE API returns empty data array on successful PUT.
+	// In that case, fetch the updated resource via GET.
+	if len(respBody.Data) == 0 {
+		return c.getAccount(ctx, site, d.ID)
+	}
+
 	if len(respBody.Data) != 1 {
 		return nil, &NotFoundError{}
 	}

--- a/unifi/broadcast_group.generated.go
+++ b/unifi/broadcast_group.generated.go
@@ -172,6 +172,12 @@ func (c *ApiClient) updateBroadcastGroup(
 		return nil, err
 	}
 
+	// UDM SE API returns empty data array on successful PUT.
+	// In that case, fetch the updated resource via GET.
+	if len(respBody.Data) == 0 {
+		return c.getBroadcastGroup(ctx, site, d.ID)
+	}
+
 	if len(respBody.Data) != 1 {
 		return nil, &NotFoundError{}
 	}

--- a/unifi/channel_plan.generated.go
+++ b/unifi/channel_plan.generated.go
@@ -206,6 +206,12 @@ func (c *ApiClient) updateChannelPlan(
 		return nil, err
 	}
 
+	// UDM SE API returns empty data array on successful PUT.
+	// In that case, fetch the updated resource via GET.
+	if len(respBody.Data) == 0 {
+		return c.getChannelPlan(ctx, site, d.ID)
+	}
+
 	if len(respBody.Data) != 1 {
 		return nil, &NotFoundError{}
 	}

--- a/unifi/client.generated.go
+++ b/unifi/client.generated.go
@@ -189,6 +189,12 @@ func (c *ApiClient) updateClient(
 		return nil, err
 	}
 
+	// UDM SE API returns empty data array on successful PUT.
+	// In that case, fetch the updated resource via GET.
+	if len(respBody.Data) == 0 {
+		return c.getClient(ctx, site, d.ID)
+	}
+
 	if len(respBody.Data) != 1 {
 		return nil, &NotFoundError{}
 	}

--- a/unifi/client_group.generated.go
+++ b/unifi/client_group.generated.go
@@ -173,6 +173,12 @@ func (c *ApiClient) updateClientGroup(
 		return nil, err
 	}
 
+	// UDM SE API returns empty data array on successful PUT.
+	// In that case, fetch the updated resource via GET.
+	if len(respBody.Data) == 0 {
+		return c.getClientGroup(ctx, site, d.ID)
+	}
+
 	if len(respBody.Data) != 1 {
 		return nil, &NotFoundError{}
 	}

--- a/unifi/dashboard.generated.go
+++ b/unifi/dashboard.generated.go
@@ -198,6 +198,12 @@ func (c *ApiClient) updateDashboard(
 		return nil, err
 	}
 
+	// UDM SE API returns empty data array on successful PUT.
+	// In that case, fetch the updated resource via GET.
+	if len(respBody.Data) == 0 {
+		return c.getDashboard(ctx, site, d.ID)
+	}
+
 	if len(respBody.Data) != 1 {
 		return nil, &NotFoundError{}
 	}

--- a/unifi/device.generated.go
+++ b/unifi/device.generated.go
@@ -721,6 +721,12 @@ func (c *ApiClient) updateDevice(
 		return nil, err
 	}
 
+	// UDM SE API returns empty data array on successful PUT.
+	// In that case, fetch the updated resource via GET.
+	if len(respBody.Data) == 0 {
+		return c.getDevice(ctx, site, d.ID)
+	}
+
 	if len(respBody.Data) != 1 {
 		return nil, &NotFoundError{}
 	}

--- a/unifi/dhcp_option.generated.go
+++ b/unifi/dhcp_option.generated.go
@@ -175,6 +175,12 @@ func (c *ApiClient) updateDHCPOption(
 		return nil, err
 	}
 
+	// UDM SE API returns empty data array on successful PUT.
+	// In that case, fetch the updated resource via GET.
+	if len(respBody.Data) == 0 {
+		return c.getDHCPOption(ctx, site, d.ID)
+	}
+
 	if len(respBody.Data) != 1 {
 		return nil, &NotFoundError{}
 	}

--- a/unifi/dpi_app.generated.go
+++ b/unifi/dpi_app.generated.go
@@ -178,6 +178,12 @@ func (c *ApiClient) updateDpiApp(
 		return nil, err
 	}
 
+	// UDM SE API returns empty data array on successful PUT.
+	// In that case, fetch the updated resource via GET.
+	if len(respBody.Data) == 0 {
+		return c.getDpiApp(ctx, site, d.ID)
+	}
+
 	if len(respBody.Data) != 1 {
 		return nil, &NotFoundError{}
 	}

--- a/unifi/dpi_group.generated.go
+++ b/unifi/dpi_group.generated.go
@@ -173,6 +173,12 @@ func (c *ApiClient) updateDpiGroup(
 		return nil, err
 	}
 
+	// UDM SE API returns empty data array on successful PUT.
+	// In that case, fetch the updated resource via GET.
+	if len(respBody.Data) == 0 {
+		return c.getDpiGroup(ctx, site, d.ID)
+	}
+
 	if len(respBody.Data) != 1 {
 		return nil, &NotFoundError{}
 	}

--- a/unifi/dynamic_dns.generated.go
+++ b/unifi/dynamic_dns.generated.go
@@ -178,6 +178,12 @@ func (c *ApiClient) updateDynamicDNS(
 		return nil, err
 	}
 
+	// UDM SE API returns empty data array on successful PUT.
+	// In that case, fetch the updated resource via GET.
+	if len(respBody.Data) == 0 {
+		return c.getDynamicDNS(ctx, site, d.ID)
+	}
+
 	if len(respBody.Data) != 1 {
 		return nil, &NotFoundError{}
 	}

--- a/unifi/firewall_group.generated.go
+++ b/unifi/firewall_group.generated.go
@@ -173,6 +173,12 @@ func (c *ApiClient) updateFirewallGroup(
 		return nil, err
 	}
 
+	// UDM SE API returns empty data array on successful PUT.
+	// In that case, fetch the updated resource via GET.
+	if len(respBody.Data) == 0 {
+		return c.getFirewallGroup(ctx, site, d.ID)
+	}
+
 	if len(respBody.Data) != 1 {
 		return nil, &NotFoundError{}
 	}

--- a/unifi/firewall_rule.generated.go
+++ b/unifi/firewall_rule.generated.go
@@ -200,6 +200,12 @@ func (c *ApiClient) updateFirewallRule(
 		return nil, err
 	}
 
+	// UDM SE API returns empty data array on successful PUT.
+	// In that case, fetch the updated resource via GET.
+	if len(respBody.Data) == 0 {
+		return c.getFirewallRule(ctx, site, d.ID)
+	}
+
 	if len(respBody.Data) != 1 {
 		return nil, &NotFoundError{}
 	}

--- a/unifi/heat_map.generated.go
+++ b/unifi/heat_map.generated.go
@@ -174,6 +174,12 @@ func (c *ApiClient) updateHeatMap(
 		return nil, err
 	}
 
+	// UDM SE API returns empty data array on successful PUT.
+	// In that case, fetch the updated resource via GET.
+	if len(respBody.Data) == 0 {
+		return c.getHeatMap(ctx, site, d.ID)
+	}
+
 	if len(respBody.Data) != 1 {
 		return nil, &NotFoundError{}
 	}

--- a/unifi/heat_map_point.generated.go
+++ b/unifi/heat_map_point.generated.go
@@ -175,6 +175,12 @@ func (c *ApiClient) updateHeatMapPoint(
 		return nil, err
 	}
 
+	// UDM SE API returns empty data array on successful PUT.
+	// In that case, fetch the updated resource via GET.
+	if len(respBody.Data) == 0 {
+		return c.getHeatMapPoint(ctx, site, d.ID)
+	}
+
 	if len(respBody.Data) != 1 {
 		return nil, &NotFoundError{}
 	}

--- a/unifi/hotspot_2_conf.generated.go
+++ b/unifi/hotspot_2_conf.generated.go
@@ -491,6 +491,12 @@ func (c *ApiClient) updateHotspot2Conf(
 		return nil, err
 	}
 
+	// UDM SE API returns empty data array on successful PUT.
+	// In that case, fetch the updated resource via GET.
+	if len(respBody.Data) == 0 {
+		return c.getHotspot2Conf(ctx, site, d.ID)
+	}
+
 	if len(respBody.Data) != 1 {
 		return nil, &NotFoundError{}
 	}

--- a/unifi/hotspot_op.generated.go
+++ b/unifi/hotspot_op.generated.go
@@ -173,6 +173,12 @@ func (c *ApiClient) updateHotspotOp(
 		return nil, err
 	}
 
+	// UDM SE API returns empty data array on successful PUT.
+	// In that case, fetch the updated resource via GET.
+	if len(respBody.Data) == 0 {
+		return c.getHotspotOp(ctx, site, d.ID)
+	}
+
 	if len(respBody.Data) != 1 {
 		return nil, &NotFoundError{}
 	}

--- a/unifi/hotspot_package.generated.go
+++ b/unifi/hotspot_package.generated.go
@@ -199,6 +199,12 @@ func (c *ApiClient) updateHotspotPackage(
 		return nil, err
 	}
 
+	// UDM SE API returns empty data array on successful PUT.
+	// In that case, fetch the updated resource via GET.
+	if len(respBody.Data) == 0 {
+		return c.getHotspotPackage(ctx, site, d.ID)
+	}
+
 	if len(respBody.Data) != 1 {
 		return nil, &NotFoundError{}
 	}

--- a/unifi/map.generated.go
+++ b/unifi/map.generated.go
@@ -183,6 +183,12 @@ func (c *ApiClient) updateMap(
 		return nil, err
 	}
 
+	// UDM SE API returns empty data array on successful PUT.
+	// In that case, fetch the updated resource via GET.
+	if len(respBody.Data) == 0 {
+		return c.getMap(ctx, site, d.ID)
+	}
+
 	if len(respBody.Data) != 1 {
 		return nil, &NotFoundError{}
 	}

--- a/unifi/media_file.generated.go
+++ b/unifi/media_file.generated.go
@@ -171,6 +171,12 @@ func (c *ApiClient) updateMediaFile(
 		return nil, err
 	}
 
+	// UDM SE API returns empty data array on successful PUT.
+	// In that case, fetch the updated resource via GET.
+	if len(respBody.Data) == 0 {
+		return c.getMediaFile(ctx, site, d.ID)
+	}
+
 	if len(respBody.Data) != 1 {
 		return nil, &NotFoundError{}
 	}

--- a/unifi/network.generated.go
+++ b/unifi/network.generated.go
@@ -527,6 +527,12 @@ func (c *ApiClient) updateNetwork(
 		return nil, err
 	}
 
+	// UDM SE API returns empty data array on successful PUT.
+	// In that case, fetch the updated resource via GET.
+	if len(respBody.Data) == 0 {
+		return c.getNetwork(ctx, site, d.ID)
+	}
+
 	if len(respBody.Data) != 1 {
 		return nil, &NotFoundError{}
 	}

--- a/unifi/port_forward.generated.go
+++ b/unifi/port_forward.generated.go
@@ -205,6 +205,12 @@ func (c *ApiClient) updatePortForward(
 		return nil, err
 	}
 
+	// UDM SE API returns empty data array on successful PUT.
+	// In that case, fetch the updated resource via GET.
+	if len(respBody.Data) == 0 {
+		return c.getPortForward(ctx, site, d.ID)
+	}
+
 	if len(respBody.Data) != 1 {
 		return nil, &NotFoundError{}
 	}

--- a/unifi/port_profile.generated.go
+++ b/unifi/port_profile.generated.go
@@ -300,6 +300,12 @@ func (c *ApiClient) updatePortProfile(
 		return nil, err
 	}
 
+	// UDM SE API returns empty data array on successful PUT.
+	// In that case, fetch the updated resource via GET.
+	if len(respBody.Data) == 0 {
+		return c.getPortProfile(ctx, site, d.ID)
+	}
+
 	if len(respBody.Data) != 1 {
 		return nil, &NotFoundError{}
 	}

--- a/unifi/radius_profile.generated.go
+++ b/unifi/radius_profile.generated.go
@@ -252,6 +252,12 @@ func (c *ApiClient) updateRADIUSProfile(
 		return nil, err
 	}
 
+	// UDM SE API returns empty data array on successful PUT.
+	// In that case, fetch the updated resource via GET.
+	if len(respBody.Data) == 0 {
+		return c.getRADIUSProfile(ctx, site, d.ID)
+	}
+
 	if len(respBody.Data) != 1 {
 		return nil, &NotFoundError{}
 	}

--- a/unifi/routing.generated.go
+++ b/unifi/routing.generated.go
@@ -180,6 +180,12 @@ func (c *ApiClient) updateRouting(
 		return nil, err
 	}
 
+	// UDM SE API returns empty data array on successful PUT.
+	// In that case, fetch the updated resource via GET.
+	if len(respBody.Data) == 0 {
+		return c.getRouting(ctx, site, d.ID)
+	}
+
 	if len(respBody.Data) != 1 {
 		return nil, &NotFoundError{}
 	}

--- a/unifi/schedule_task.generated.go
+++ b/unifi/schedule_task.generated.go
@@ -195,6 +195,12 @@ func (c *ApiClient) updateScheduleTask(
 		return nil, err
 	}
 
+	// UDM SE API returns empty data array on successful PUT.
+	// In that case, fetch the updated resource via GET.
+	if len(respBody.Data) == 0 {
+		return c.getScheduleTask(ctx, site, d.ID)
+	}
+
 	if len(respBody.Data) != 1 {
 		return nil, &NotFoundError{}
 	}

--- a/unifi/spatial_record.generated.go
+++ b/unifi/spatial_record.generated.go
@@ -215,6 +215,12 @@ func (c *ApiClient) updateSpatialRecord(
 		return nil, err
 	}
 
+	// UDM SE API returns empty data array on successful PUT.
+	// In that case, fetch the updated resource via GET.
+	if len(respBody.Data) == 0 {
+		return c.getSpatialRecord(ctx, site, d.ID)
+	}
+
 	if len(respBody.Data) != 1 {
 		return nil, &NotFoundError{}
 	}

--- a/unifi/tag.generated.go
+++ b/unifi/tag.generated.go
@@ -172,6 +172,12 @@ func (c *ApiClient) updateTag(
 		return nil, err
 	}
 
+	// UDM SE API returns empty data array on successful PUT.
+	// In that case, fetch the updated resource via GET.
+	if len(respBody.Data) == 0 {
+		return c.getTag(ctx, site, d.ID)
+	}
+
 	if len(respBody.Data) != 1 {
 		return nil, &NotFoundError{}
 	}

--- a/unifi/virtual_device.generated.go
+++ b/unifi/virtual_device.generated.go
@@ -176,6 +176,12 @@ func (c *ApiClient) updateVirtualDevice(
 		return nil, err
 	}
 
+	// UDM SE API returns empty data array on successful PUT.
+	// In that case, fetch the updated resource via GET.
+	if len(respBody.Data) == 0 {
+		return c.getVirtualDevice(ctx, site, d.ID)
+	}
+
 	if len(respBody.Data) != 1 {
 		return nil, &NotFoundError{}
 	}

--- a/unifi/wlan.generated.go
+++ b/unifi/wlan.generated.go
@@ -579,6 +579,12 @@ func (c *ApiClient) updateWLAN(
 		return nil, err
 	}
 
+	// UDM SE API returns empty data array on successful PUT.
+	// In that case, fetch the updated resource via GET.
+	if len(respBody.Data) == 0 {
+		return c.getWLAN(ctx, site, d.ID)
+	}
+
 	if len(respBody.Data) != 1 {
 		return nil, &NotFoundError{}
 	}

--- a/unifi/wlan_group.generated.go
+++ b/unifi/wlan_group.generated.go
@@ -171,6 +171,12 @@ func (c *ApiClient) updateWLANGroup(
 		return nil, err
 	}
 
+	// UDM SE API returns empty data array on successful PUT.
+	// In that case, fetch the updated resource via GET.
+	if len(respBody.Data) == 0 {
+		return c.getWLANGroup(ctx, site, d.ID)
+	}
+
 	if len(respBody.Data) != 1 {
 		return nil, &NotFoundError{}
 	}


### PR DESCRIPTION
## Summary

UDM SE returns `{"meta":{"rc":"ok"},"data":[]}` on successful PUT operations instead of returning the updated resource in the data array. This caused "not found" errors when updating resources.

## Changes

- Update `api.go.tmpl` to detect empty data array on PUT responses
- When `data: []` is returned, fetch the resource via GET to return the updated state
- Regenerate all affected `.generated.go` files

## Testing

Tested against UDM SE running UniFi Network 10.1.83 where this issue was encountered.