### PR TITLE
fix(device): stabilize UpdateDevice for cloud connector proxy

### DIFF
--- a/unifi/device.go
+++ b/unifi/device.go
@@ -250,7 +250,12 @@ func (c *ApiClient) UpdateDevice(ctx context.Context, site string, d *Device) (*
 		return nil, err
 	}
 
+	// Through the cloud connector proxy the PUT response may have an empty data
+	// array even on success. Re-read by MAC to get the updated device.
 	if len(respBody.Data) != 1 {
+		if d.MAC != "" {
+			return c.getDevice(ctx, site, d.MAC)
+		}
 		return nil, &NotFoundError{}
 	}
 
@@ -312,7 +317,12 @@ func getDiff[T any](original, target *T, skipFields ...string) (map[string]any, 
 
 // getDeviceDiff compares two Device objects and returns a map containing only changed fields.
 func getDeviceDiff(original, target *Device) (map[string]any, error) {
-	return getDiff(original, target, "_id", "site_id")
+	patch, err := getDiff(original, target, "_id", "site_id", "adopted", "state")
+	if err != nil {
+		return nil, err
+	}
+
+	return patch, nil
 }
 
 // deepEqualJSON compares two values for deep equality by comparing their JSON representations.


### PR DESCRIPTION
When using the UniFi cloud connector proxy (`https://api.ui.com/v1/connector/consoles/{id}/proxy/...`), a successful PUT to the device endpoint can return an empty `data` array rather than the updated device object. The existing code treats this as `NotFoundError`, making `UpdateDevice` unreliable through the cloud connector.

Additionally, `adopted` and `state` are read-only fields that the controller rejects when included in a PATCH body, causing unnecessary noise or errors when their values happen to differ.

## Changes

 - **`unifi/device.go` — `UpdateDevice`**: when the PUT response has an empty `data` array and the device MAC is known, fall back to a `getDevice` lookup by MAC instead of returning `NotFoundError`.
 - **`unifi/device.go` — `getDeviceDiff`**: exclude `adopted` and `state` from the diff patch, as both are server-controlled read-only fields.
