### PR TITLE
new api fields

### DIFF
--- a/cmd/fields/custom/FirewallPolicy.json
+++ b/cmd/fields/custom/FirewallPolicy.json
@@ -8,10 +8,17 @@
     "ips": [
       ""
     ],
+    "client_macs": [
+      ""
+    ],
+    "network_ids": [
+      ""
+    ],
     "match_mac": "true|false",
     "match_opposite_ips": "true|false",
     "match_opposite_ports": "true|false",
-    "matching_target": "ANY|DEVICE|IP|NETWORK|MAC",
+    "match_opposite_networks": "true|false",
+    "matching_target": "ANY|DEVICE|IP|NETWORK|CLIENT|MAC",
     "matching_target_type": "ANY|SPECIFIC|LIST|OBJECT",
     "port": "[1-9][0-9]{0,4}",
     "port_group_id": "",
@@ -43,10 +50,17 @@
     "ips": [
       ""
     ],
+    "client_macs": [
+      ""
+    ],
+    "network_ids": [
+      ""
+    ],
     "match_mac": "true|false",
     "match_opposite_ips": "true|false",
     "match_opposite_ports": "true|false",
-    "matching_target": "ANY|DEVICE|IP|NETWORK|MAC",
+    "match_opposite_networks": "true|false",
+    "matching_target": "ANY|DEVICE|IP|NETWORK|CLIENT|MAC",
     "matching_target_type": "ANY|SPECIFIC|LIST|OBJECT",
     "port": "[1-9][0-9]{0,4}",
     "port_group_id": "",

--- a/cmd/fields/main.go
+++ b/cmd/fields/main.go
@@ -583,6 +583,13 @@ func main() {
 			continue
 		}
 
+		// Add fields not present in the JAR schema to nested types.
+		if resource.StructName == "Device" {
+			if portOverrides, ok := resource.Types["DevicePortOverrides"]; ok {
+				portOverrides.Fields["TaggedNetworkIDs"] = NewFieldInfo("TaggedNetworkIDs", "tagged_networkconf_ids", fields.String, "", true, true, false, "")
+			}
+		}
+
 		// Add resource to specification generator
 		specGen.AddResource(resource)
 

--- a/unifi/device.generated.go
+++ b/unifi/device.generated.go
@@ -492,6 +492,7 @@ type DevicePortOverrides struct {
 	StormctrlUcastLevel          *int64            `json:"stormctrl_ucast_level,omitempty"` // [0-9]|[1-9][0-9]|100
 	StormctrlUcastRate           *int64            `json:"stormctrl_ucast_rate,omitempty"`  // [0-9]|[1-9][0-9]{1,6}|1[0-3][0-9]{6}|14[0-7][0-9]{5}|148[0-7][0-9]{4}|14880000
 	StpPortMode                  bool              `json:"stp_port_mode,omitempty"`
+	TaggedNetworkIDs             []string          `json:"tagged_networkconf_ids,omitempty"`
 	TaggedVLANMgmt               string            `json:"tagged_vlan_mgmt,omitempty"` // auto|block_all|custom
 	VoiceNetworkID               string            `json:"voice_networkconf_id,omitempty"`
 }

--- a/unifi/firewall_policy.generated.go
+++ b/unifi/firewall_policy.generated.go
@@ -81,16 +81,19 @@ func (dst *FirewallPolicy) UnmarshalJSON(b []byte) error {
 }
 
 type FirewallPolicyDestination struct {
-	IPs                []string `json:"ips,omitempty"`
-	MatchMAC           bool     `json:"match_mac"`
-	MatchOppositeIPs   bool     `json:"match_opposite_ips"`
-	MatchOppositePorts bool     `json:"match_opposite_ports"`
-	MatchingTarget     string   `json:"matching_target,omitempty"`      // ANY|DEVICE|IP|NETWORK|MAC
-	MatchingTargetType string   `json:"matching_target_type,omitempty"` // ANY|SPECIFIC|LIST|OBJECT
-	Port               *int64   `json:"port,omitempty"`                 // [1-9][0-9]{0,4}
-	PortGroupID        string   `json:"port_group_id,omitempty"`
-	PortMatchingType   string   `json:"port_matching_type,omitempty"` // ANY|SPECIFIC|LIST|OBJECT
-	ZoneID             string   `json:"zone_id,omitempty"`
+	ClientMACs            []string `json:"client_macs,omitempty"`
+	IPs                   []string `json:"ips,omitempty"`
+	MatchMAC              bool     `json:"match_mac"`
+	MatchOppositeIPs      bool     `json:"match_opposite_ips"`
+	MatchOppositeNetworks bool     `json:"match_opposite_networks"`
+	MatchOppositePorts    bool     `json:"match_opposite_ports"`
+	MatchingTarget        string   `json:"matching_target,omitempty"`      // ANY|DEVICE|IP|NETWORK|CLIENT|MAC
+	MatchingTargetType    string   `json:"matching_target_type,omitempty"` // ANY|SPECIFIC|LIST|OBJECT
+	NetworkIDs            []string `json:"network_ids,omitempty"`
+	Port                  *int64   `json:"port,omitempty"` // [1-9][0-9]{0,4}
+	PortGroupID           string   `json:"port_group_id,omitempty"`
+	PortMatchingType      string   `json:"port_matching_type,omitempty"` // ANY|SPECIFIC|LIST|OBJECT
+	ZoneID                string   `json:"zone_id,omitempty"`
 }
 
 func (dst *FirewallPolicyDestination) UnmarshalJSON(b []byte) error {
@@ -145,16 +148,19 @@ func (dst *FirewallPolicySchedule) UnmarshalJSON(b []byte) error {
 }
 
 type FirewallPolicySource struct {
-	IPs                []string `json:"ips,omitempty"`
-	MatchMAC           bool     `json:"match_mac"`
-	MatchOppositeIPs   bool     `json:"match_opposite_ips"`
-	MatchOppositePorts bool     `json:"match_opposite_ports"`
-	MatchingTarget     string   `json:"matching_target,omitempty"`      // ANY|DEVICE|IP|NETWORK|MAC
-	MatchingTargetType string   `json:"matching_target_type,omitempty"` // ANY|SPECIFIC|LIST|OBJECT
-	Port               *int64   `json:"port,omitempty"`                 // [1-9][0-9]{0,4}
-	PortGroupID        string   `json:"port_group_id,omitempty"`
-	PortMatchingType   string   `json:"port_matching_type,omitempty"` // ANY|SPECIFIC|LIST|OBJECT
-	ZoneID             string   `json:"zone_id,omitempty"`
+	ClientMACs            []string `json:"client_macs,omitempty"`
+	IPs                   []string `json:"ips,omitempty"`
+	MatchMAC              bool     `json:"match_mac"`
+	MatchOppositeIPs      bool     `json:"match_opposite_ips"`
+	MatchOppositeNetworks bool     `json:"match_opposite_networks"`
+	MatchOppositePorts    bool     `json:"match_opposite_ports"`
+	MatchingTarget        string   `json:"matching_target,omitempty"`      // ANY|DEVICE|IP|NETWORK|CLIENT|MAC
+	MatchingTargetType    string   `json:"matching_target_type,omitempty"` // ANY|SPECIFIC|LIST|OBJECT
+	NetworkIDs            []string `json:"network_ids,omitempty"`
+	Port                  *int64   `json:"port,omitempty"` // [1-9][0-9]{0,4}
+	PortGroupID           string   `json:"port_group_id,omitempty"`
+	PortMatchingType      string   `json:"port_matching_type,omitempty"` // ANY|SPECIFIC|LIST|OBJECT
+	ZoneID                string   `json:"zone_id,omitempty"`
 }
 
 func (dst *FirewallPolicySource) UnmarshalJSON(b []byte) error {


### PR DESCRIPTION
This contains two classes of additions to the client.

## 1 new fields in non-JAR-extracted APIs
Adds `ClientMACs`, `NetworkIDs`, and `MatchOppositeNetworks` to both `FirewallPolicySource` and `FirewallPolicyDestination`, and recognises `CLIENT` as a valid `MatchingTarget` value. These fields correspond to targeting capabilities available in recent UniFi firmware versions.

`FirewallPolicy` is a v2/cloud-only resource with no JAR equivalent; its schema lives entirely in `cmd/fields/custom/FirewallPolicy.json`.

## 2 new field in JAR-extracted field

Exposes the `tagged_networkconf_ids` JSON field in `DevicePortOverrides` so callers can manage which tagged VLAN networks are assigned to a port.
                                                                                                                                                                 
The field is not present in the on-premises controller JAR schema, and I do not fully understand why. I work with the cloud connector only, maybe there is a difference in APIs? I injected the field via post-processing in `cmd/fields/main.go` rather than the JAR JSON.