### PR TITLE
fix: survive controller login rate-limit (HTTP 429) on /api/auth/login

### DIFF
--- a/unifi/errors.go
+++ b/unifi/errors.go
@@ -1,6 +1,29 @@
 package unifi
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
+
+// RateLimitError indicates the controller rejected a request with HTTP 429
+// (Too Many Requests). UniFi rate-limits POST /api/auth/login in particular, so
+// a workflow that re-authenticates on every operation (username/password) can
+// exhaust the limit. RetryAfter carries the controller's Retry-After hint when
+// provided. Using API-key auth (UNIFI_API_KEY) avoids the per-request login
+// entirely.
+type RateLimitError struct {
+	RetryAfter time.Duration
+}
+
+func (err *RateLimitError) Error() string {
+	if err.RetryAfter > 0 {
+		return fmt.Sprintf(
+			"rate limited by controller (retry after %s); consider API-key auth to avoid per-run login",
+			err.RetryAfter,
+		)
+	}
+	return "rate limited by controller; consider API-key auth to avoid per-run login"
+}
 
 type LoginRequiredError struct {
 	APIKey bool // true when the rejection is for an API-key request

--- a/unifi/login_test.go
+++ b/unifi/login_test.go
@@ -36,9 +36,10 @@ func shortLoginBackoff(t *testing.T) {
 }
 
 // TestLogin_RateLimitedThenSucceeds proves a normal workflow survives the
-// controller's login rate-limit: the controller returns several HTTP 429s before
-// accepting the login, and New() must retry until it succeeds rather than failing
-// with a confusing "unable to login" error.
+// controller's login rate-limit: the controller returns several HTTP 429s
+// (with no Retry-After, as a real UDM-Pro does) before accepting the login, and
+// New() must back off exponentially and retry until it succeeds rather than
+// failing with a confusing "unable to login" error.
 func TestLogin_RateLimitedThenSucceeds(t *testing.T) {
 	shortLoginBackoff(t)
 
@@ -52,7 +53,7 @@ func TestLogin_RateLimitedThenSucceeds(t *testing.T) {
 		if r.Method == http.MethodPost && r.URL.Path == loginPathNew {
 			n := atomic.AddInt32(&loginHits, 1)
 			if n <= rateLimitedAttempts {
-				w.Header().Set("Retry-After", "0")
+				// No Retry-After header — matches real UniFi behavior.
 				w.WriteHeader(http.StatusTooManyRequests)
 				return
 			}
@@ -129,7 +130,6 @@ func TestLogin_ExhaustionReturnsRateLimitError(t *testing.T) {
 			return
 		}
 		if r.Method == http.MethodPost && r.URL.Path == loginPathNew {
-			w.Header().Set("Retry-After", "0")
 			w.WriteHeader(http.StatusTooManyRequests)
 			return
 		}

--- a/unifi/login_test.go
+++ b/unifi/login_test.go
@@ -1,0 +1,227 @@
+package unifi
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// handleNewStyleSetup answers the unauthenticated probe (GET /) and the
+// best-effort version lookup so New() can reach the login step against a
+// new-style (UniFi OS) controller. Returns true if it handled the request.
+func handleNewStyleSetup(w http.ResponseWriter, r *http.Request) bool {
+	switch {
+	case r.Method == http.MethodGet && r.URL.Path == "/":
+		w.WriteHeader(http.StatusOK) // 200 => new-style API
+		return true
+	case r.URL.Path == "/proxy/network/status":
+		_, _ = w.Write([]byte(`{"meta":{"server_version":"8.0.0"}}`))
+		return true
+	}
+	return false
+}
+
+// shortLoginBackoff shrinks the inter-attempt backoff so rate-limit tests run
+// fast, restoring the production default afterwards. Honored Retry-After waits
+// are unaffected (they come from the response, not loginRetryBackoff).
+func shortLoginBackoff(t *testing.T) {
+	t.Helper()
+	prev := loginRetryBackoff
+	loginRetryBackoff = 5 * time.Millisecond
+	t.Cleanup(func() { loginRetryBackoff = prev })
+}
+
+// TestLogin_RateLimitedThenSucceeds proves a normal workflow survives the
+// controller's login rate-limit: the controller returns several HTTP 429s before
+// accepting the login, and New() must retry until it succeeds rather than failing
+// with a confusing "unable to login" error.
+func TestLogin_RateLimitedThenSucceeds(t *testing.T) {
+	shortLoginBackoff(t)
+
+	var loginHits int32
+	const rateLimitedAttempts = 5
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if handleNewStyleSetup(w, r) {
+			return
+		}
+		if r.Method == http.MethodPost && r.URL.Path == loginPathNew {
+			n := atomic.AddInt32(&loginHits, 1)
+			if n <= rateLimitedAttempts {
+				w.Header().Set("Retry-After", "0")
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
+			w.Header().Set("X-Csrf-Token", "tok")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	_, err := New(context.Background(), &Config{
+		BaseURL:  srv.URL,
+		Username: "admin",
+		Password: "admin",
+	})
+	if err != nil {
+		t.Fatalf("expected login to survive %d rate-limited attempts, got error: %v", rateLimitedAttempts, err)
+	}
+	if got := atomic.LoadInt32(&loginHits); got != rateLimitedAttempts+1 {
+		t.Errorf("expected %d login attempts, got %d", rateLimitedAttempts+1, got)
+	}
+}
+
+// TestLogin_HonorsRetryAfter verifies the controller's Retry-After hint is waited
+// out (rather than retried immediately).
+func TestLogin_HonorsRetryAfter(t *testing.T) {
+	shortLoginBackoff(t)
+
+	var loginHits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if handleNewStyleSetup(w, r) {
+			return
+		}
+		if r.Method == http.MethodPost && r.URL.Path == loginPathNew {
+			if atomic.AddInt32(&loginHits, 1) == 1 {
+				w.Header().Set("Retry-After", "1") // 1 second
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
+			w.Header().Set("X-Csrf-Token", "tok")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	start := time.Now()
+	_, err := New(context.Background(), &Config{
+		BaseURL:  srv.URL,
+		Username: "admin",
+		Password: "admin",
+	})
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if elapsed < 900*time.Millisecond {
+		t.Errorf("expected to honor Retry-After ~1s, but login took only %s", elapsed)
+	}
+}
+
+// TestLogin_ExhaustionReturnsRateLimitError verifies that a persistent rate-limit
+// surfaces a clear, typed RateLimitError instead of an opaque "giving up" message.
+func TestLogin_ExhaustionReturnsRateLimitError(t *testing.T) {
+	shortLoginBackoff(t)
+	prevMax := loginRetryMax
+	loginRetryMax = 3
+	t.Cleanup(func() { loginRetryMax = prevMax })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if handleNewStyleSetup(w, r) {
+			return
+		}
+		if r.Method == http.MethodPost && r.URL.Path == loginPathNew {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	_, err := New(context.Background(), &Config{
+		BaseURL:  srv.URL,
+		Username: "admin",
+		Password: "admin",
+	})
+	if err == nil {
+		t.Fatal("expected an error when the controller never clears the rate-limit")
+	}
+	var rle *RateLimitError
+	if !errors.As(err, &rle) {
+		t.Errorf("expected error to unwrap to *RateLimitError, got: %v", err)
+	}
+}
+
+// TestLogin_EmptyBodyResponseRetries verifies that a 2xx response that does not
+// establish a session (e.g. an empty body under throttling) is retried rather
+// than accepted as a broken "logged-in" state.
+func TestLogin_EmptyBodyResponseRetries(t *testing.T) {
+	shortLoginBackoff(t)
+
+	var loginHits int32
+	const emptyAttempts = 2
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if handleNewStyleSetup(w, r) {
+			return
+		}
+		if r.Method == http.MethodPost && r.URL.Path == loginPathNew {
+			n := atomic.AddInt32(&loginHits, 1)
+			if n <= emptyAttempts {
+				w.WriteHeader(http.StatusOK) // 200 but no CSRF token => no session
+				return
+			}
+			w.Header().Set("X-Csrf-Token", "tok")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	_, err := New(context.Background(), &Config{
+		BaseURL:  srv.URL,
+		Username: "admin",
+		Password: "admin",
+	})
+	if err != nil {
+		t.Fatalf("expected retry past empty-body responses, got error: %v", err)
+	}
+	if got := atomic.LoadInt32(&loginHits); got != emptyAttempts+1 {
+		t.Errorf("expected %d login attempts, got %d", emptyAttempts+1, got)
+	}
+}
+
+// TestLogin_APIKeySkipsLogin verifies API-key auth issues no POST /api/auth/login
+// at all (and sends the key as a header), which is the definitive way to avoid the
+// login rate-limit across separate Terraform invocations.
+func TestLogin_APIKeySkipsLogin(t *testing.T) {
+	var loginHits int32
+	var sawAPIKey atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Api-Key") != "" {
+			sawAPIKey.Store(true)
+		}
+		if r.Method == http.MethodPost && r.URL.Path == loginPathNew {
+			atomic.AddInt32(&loginHits, 1)
+		}
+		if r.URL.Path == "/proxy/network/status" {
+			_, _ = w.Write([]byte(`{"meta":{"server_version":"8.0.0"}}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	_, err := New(context.Background(), &Config{
+		BaseURL: srv.URL,
+		APIKey:  "secret-key",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := atomic.LoadInt32(&loginHits); got != 0 {
+		t.Errorf("expected 0 login attempts with API key, got %d", got)
+	}
+	if !sawAPIKey.Load() {
+		t.Error("expected requests to carry the X-Api-Key header")
+	}
+}

--- a/unifi/unifi.go
+++ b/unifi/unifi.go
@@ -30,6 +30,27 @@ const (
 	loginPathNew = "/api/auth/login"
 )
 
+// errLoginNotEstablished is returned by login when the controller answers with a
+// success status but no session was established (e.g. an empty body returned
+// under a login rate-limit). It is retryable by loginWithRetry.
+var errLoginNotEstablished = errors.New("login response did not establish a session")
+
+// Login retry tuning. These are vars (not consts) so tests can shorten the
+// backoff; production code never mutates them.
+var (
+	// loginRetryMax bounds how many times loginWithRetry will attempt a login
+	// before giving up. UniFi rate-limits POST /api/auth/login, so a normal
+	// Terraform workflow (several back-to-back operations) needs more than the
+	// transport-level retry budget to ride out the limit.
+	loginRetryMax = 8
+	// loginRetryBackoff is the wait between login attempts when the controller
+	// does not provide a Retry-After hint.
+	loginRetryBackoff = 1 * time.Second
+	// loginRetryMaxWait caps an honored Retry-After so a pathological hint
+	// (e.g. Retry-After: 3600) cannot stall the whole run.
+	loginRetryMaxWait = 2 * time.Minute
+)
+
 // Config holds all configuration for creating a new ApiClient.
 type Config struct {
 	BaseURL        string
@@ -63,6 +84,16 @@ func New(ctx context.Context, cfg *Config) (*ApiClient, error) {
 
 	if cfg.RetryMax != nil {
 		c.RetryMax = *cfg.RetryMax
+	}
+
+	// Don't let the transport silently retry HTTP 429: surface it as a
+	// RateLimitError (see doRequest) so loginWithRetry can honor Retry-After
+	// with a login-specific budget. Everything else keeps the default policy.
+	c.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
+		if resp != nil && resp.StatusCode == http.StatusTooManyRequests {
+			return false, nil
+		}
+		return retryablehttp.DefaultRetryPolicy(ctx, resp, err)
 	}
 
 	if cfg.AllowInsecure {
@@ -106,7 +137,7 @@ func New(ctx context.Context, cfg *Config) (*ApiClient, error) {
 	_ = client.setAPIUrlStyle(ctx)
 
 	if cfg.Username != "" && cfg.Password != "" && client.apiKey == "" {
-		if err := client.login(ctx); err != nil {
+		if err := client.loginWithRetry(ctx); err != nil {
 			return nil, fmt.Errorf("unable to login: %w", err)
 		}
 	}
@@ -388,8 +419,56 @@ func (c *ApiClient) login(ctx context.Context) error {
 		return err
 	}
 
+	// A 2xx with no session (empty body / missing CSRF cookie) happens when the
+	// controller throttles login without a clear error status. Treat it as a
+	// retryable failure instead of a silent "logged-in but broken" state.
+	if !c.isLoggedIn() {
+		c.loginErr = errLoginNotEstablished
+		return errLoginNotEstablished
+	}
+
 	c.loginErr = nil
 	return nil
+}
+
+// loginWithRetry performs login, retrying on controller rate-limiting (HTTP 429)
+// and on success-without-session responses. It honors the controller's
+// Retry-After hint (capped by loginRetryMaxWait) so a normal Terraform workflow
+// survives the login rate-limit instead of failing with a confusing error.
+func (c *ApiClient) loginWithRetry(ctx context.Context) error {
+	var lastErr error
+	for attempt := 0; attempt < loginRetryMax; attempt++ {
+		err := c.login(ctx)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+
+		var rle *RateLimitError
+		isRateLimit := errors.As(err, &rle)
+		if !isRateLimit && !errors.Is(err, errLoginNotEstablished) {
+			return err // not a transient rate-limit condition
+		}
+
+		if attempt == loginRetryMax-1 {
+			break // don't sleep after the final attempt
+		}
+
+		wait := loginRetryBackoff
+		if isRateLimit && rle.RetryAfter > 0 {
+			wait = rle.RetryAfter
+		}
+		if wait > loginRetryMaxWait {
+			wait = loginRetryMaxWait
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(wait):
+		}
+	}
+	return lastErr
 }
 
 // ensureLoggedIn acquires an exclusive lock and performs login if needed.
@@ -410,7 +489,7 @@ func (c *ApiClient) ensureLoggedIn(ctx context.Context) error {
 
 	// Clear any stale loginErr before attempting (e.g. token-expiry refresh).
 	c.loginErr = nil
-	return c.login(ctx)
+	return c.loginWithRetry(ctx)
 }
 
 func (c *ApiClient) setServerVersion(ctx context.Context) (err error) {
@@ -565,6 +644,13 @@ func (c *ApiClient) doRequest(
 		}
 	}
 
+	// Surface controller rate-limiting (HTTP 429) as a typed error so callers
+	// (notably login) can back off honoring Retry-After instead of failing with
+	// an opaque error. The transport is configured not to retry 429 itself.
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return &RateLimitError{RetryAfter: parseRetryAfter(resp)}
+	}
+
 	if csrf := resp.Header.Get("X-Updated-Csrf-Token"); csrf != "" {
 		c.csrf = csrf
 	} else if csrf := resp.Header.Get("X-Csrf-Token"); csrf != "" {
@@ -636,6 +722,31 @@ func (m *meta) error() error {
 	}
 
 	return nil
+}
+
+// parseRetryAfter reads the Retry-After header from a 429 response, supporting
+// both the delta-seconds form ("120") and the HTTP-date form. Returns 0 when the
+// header is absent or unparseable.
+func parseRetryAfter(resp *http.Response) time.Duration {
+	if resp == nil {
+		return 0
+	}
+	v := resp.Header.Get("Retry-After")
+	if v == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(v); err == nil {
+		if secs <= 0 {
+			return 0
+		}
+		return time.Duration(secs) * time.Second
+	}
+	if t, err := http.ParseTime(v); err == nil {
+		if d := time.Until(t); d > 0 {
+			return d
+		}
+	}
+	return 0
 }
 
 func Ptr[T any](in T) *T {

--- a/unifi/unifi.go
+++ b/unifi/unifi.go
@@ -43,9 +43,15 @@ var (
 	// Terraform workflow (several back-to-back operations) needs more than the
 	// transport-level retry budget to ride out the limit.
 	loginRetryMax = 8
-	// loginRetryBackoff is the wait between login attempts when the controller
-	// does not provide a Retry-After hint.
+	// loginRetryBackoff is the base wait between login attempts when the
+	// controller sends no usable Retry-After hint. UniFi's login 429 carries
+	// none, so the wait grows exponentially from this base (capped by
+	// loginRetryBackoffCap) — with the defaults the total budget is ~90s, enough
+	// to ride out a real login-throttle window (observed ~45s on a live UDM-Pro
+	// after several back-to-back runs).
 	loginRetryBackoff = 1 * time.Second
+	// loginRetryBackoffCap caps each exponential-fallback wait.
+	loginRetryBackoffCap = 30 * time.Second
 	// loginRetryMaxWait caps an honored Retry-After so a pathological hint
 	// (e.g. Retry-After: 3600) cannot stall the whole run.
 	loginRetryMaxWait = 2 * time.Minute
@@ -454,12 +460,20 @@ func (c *ApiClient) loginWithRetry(ctx context.Context) error {
 			break // don't sleep after the final attempt
 		}
 
-		wait := loginRetryBackoff
+		var wait time.Duration
 		if isRateLimit && rle.RetryAfter > 0 {
+			// Honor the controller's Retry-After hint, capped.
 			wait = rle.RetryAfter
-		}
-		if wait > loginRetryMaxWait {
-			wait = loginRetryMaxWait
+			if wait > loginRetryMaxWait {
+				wait = loginRetryMaxWait
+			}
+		} else {
+			// No usable Retry-After (UniFi's login 429 sends none): back off
+			// exponentially from the base so a single run rides out the window.
+			wait = loginRetryBackoff << attempt
+			if wait <= 0 || wait > loginRetryBackoffCap {
+				wait = loginRetryBackoffCap
+			}
 		}
 
 		select {


### PR DESCRIPTION
## Problem

UniFi controllers rate-limit `POST /api/auth/login`. With username/password auth the SDK logs in when the client is constructed (`New`), so a normal Terraform workflow — several back-to-back operations (`init` → `import` → `plan` → `plan` → `apply`), or one apply with many resources across separate runs — can exhaust the limit. The transport (`retryablehttp`) only retries a few times, so login fails with a confusing:

```
unable to login: unable to perform request: POST /api/auth/login ... giving up after 5 attempt(s)
```

In `terraform-provider-unifi` this surfaces as `Error: Unable to Create HTTP Client`, and an identical operation run in isolation succeeds.

## Fix

Make `login` resilient to the controller's rate-limit, scoped to the login path so other request semantics are unchanged:

- Add a typed `RateLimitError{ RetryAfter time.Duration }` and map HTTP **429** to it in `doRequest` (parallel to the existing `NotFoundError`/`LoginRequiredError` mapping). `Retry-After` is parsed in both delta-seconds and HTTP-date forms.
- Configure `retryablehttp` **not** to silently retry 429, so login can back off honoring `Retry-After` with a dedicated budget (`loginWithRetry`), capped by `loginRetryMaxWait` to avoid a pathological `Retry-After` stalling the whole run.
- Treat a `2xx` login that establishes **no session** (empty body / missing CSRF — seen under throttling) as a retryable condition instead of a silent "logged-in but broken" state.
- On exhaustion, return the `*RateLimitError` so the message is clear and actionable (it points to API-key auth, which skips login entirely).

No behavior change for API-key auth (login was already skipped) or for the happy path.

## Tests

New `unifi/login_test.go` (first `httptest`-based tests here, pure unit, no controller/Docker required):

- `TestLogin_RateLimitedThenSucceeds` — survives a burst of 429s and logs in.
- `TestLogin_HonorsRetryAfter` — waits out the controller's `Retry-After`.
- `TestLogin_ExhaustionReturnsRateLimitError` — clear typed error when the limit never clears.
- `TestLogin_EmptyBodyResponseRetries` — retries a session-less 2xx.
- `TestLogin_APIKeySkipsLogin` — API-key auth issues **zero** `POST /api/auth/login` and sends `X-Api-Key`.

`go test ./...`, `go vet ./...`, and `gofmt` are clean.

## Context

Found while migrating fixed-IP reservations onto a UDM-Pro (UniFi OS 5.1.12 / Network App 10.3.58). Consumed by `terraform-provider-unifi`.
