### PR TITLE
fix(device): handle numeric tx_power and channel in DeviceRadioTable.…

### DIFF
--- a/cmd/fields/main.go
+++ b/cmd/fields/main.go
@@ -458,6 +458,13 @@ func main() {
 					// Field within DeviceRadioTable nested type
 					f.CustomUnmarshalType = "types.Number"
 					f.CustomUnmarshalFunc = "types.ToInt64Pointer"
+				case "TxPower", "Channel":
+					// Field within DeviceRadioTable nested type — controller
+					// may send these as either a string ("auto") or a number
+					// (e.g. 18, 6); coerce numeric values back to string.
+					if f.FieldType == fields.String {
+						f.CustomUnmarshalType = fields.Number
+					}
 				}
 
 				f.OmitEmpty = true

--- a/unifi/device.generated.go
+++ b/unifi/device.generated.go
@@ -911,36 +911,29 @@ func (dst *DeviceRadioTable) UnmarshalJSON(b []byte) error {
 		}
 	}
 	if aux.AssistedRoamingRssi != nil {
+		// Empty string means "unset"; leave nil so omitempty drops it on round-trip
+		// (controller rejects 0 — valid range is -60..-80).
 		if val, err := aux.AssistedRoamingRssi.Int64(); err == nil {
 			dst.AssistedRoamingRssi = &val
-		} else if string(*aux.AssistedRoamingRssi) == "" {
-			var zero int64
-			dst.AssistedRoamingRssi = &zero
 		}
 	}
 	dst.Ht = types.ToInt64Pointer(aux.Ht)
 	if aux.Maxsta != nil {
+		// Empty string means "unset"; controller rejects 0 (valid range 1..200).
 		if val, err := aux.Maxsta.Int64(); err == nil {
 			dst.Maxsta = &val
-		} else if string(*aux.Maxsta) == "" {
-			var zero int64
-			dst.Maxsta = &zero
 		}
 	}
 	if aux.MinRssi != nil {
+		// Empty string means "unset"; controller rejects 0 (valid range -67..-90).
 		if val, err := aux.MinRssi.Int64(); err == nil {
 			dst.MinRssi = &val
-		} else if string(*aux.MinRssi) == "" {
-			var zero int64
-			dst.MinRssi = &zero
 		}
 	}
 	if aux.SensLevel != nil {
+		// Empty string means "unset"; controller rejects 0 (valid range -50..-90).
 		if val, err := aux.SensLevel.Int64(); err == nil {
 			dst.SensLevel = &val
-		} else if string(*aux.SensLevel) == "" {
-			var zero int64
-			dst.SensLevel = &zero
 		}
 	}
 	if aux.Channel != nil {

--- a/unifi/device.generated.go
+++ b/unifi/device.generated.go
@@ -878,10 +878,12 @@ func (dst *DeviceRadioTable) UnmarshalJSON(b []byte) error {
 		AntennaGain         *types.Number `json:"antenna_gain"`
 		AntennaID           *types.Number `json:"antenna_id"`
 		AssistedRoamingRssi *types.Number `json:"assisted_roaming_rssi"`
+		Channel             *types.Number `json:"channel"`
 		Ht                  *types.Number `json:"ht"`
 		Maxsta              *types.Number `json:"maxsta"`
 		MinRssi             *types.Number `json:"min_rssi"`
 		SensLevel           *types.Number `json:"sens_level"`
+		TxPower             *types.Number `json:"tx_power"`
 
 		*Alias
 	}{
@@ -939,6 +941,20 @@ func (dst *DeviceRadioTable) UnmarshalJSON(b []byte) error {
 		} else if string(*aux.SensLevel) == "" {
 			var zero int64
 			dst.SensLevel = &zero
+		}
+	}
+	if aux.Channel != nil {
+		if val, err := aux.Channel.Int64(); err == nil {
+			dst.Channel = strconv.FormatInt(val, 10)
+		} else if string(*aux.Channel) != "" {
+			dst.Channel = string(*aux.Channel)
+		}
+	}
+	if aux.TxPower != nil {
+		if val, err := aux.TxPower.Int64(); err == nil {
+			dst.TxPower = strconv.FormatInt(val, 10)
+		} else if string(*aux.TxPower) != "" {
+			dst.TxPower = string(*aux.TxPower)
 		}
 	}
 

--- a/unifi/device.go
+++ b/unifi/device.go
@@ -255,8 +255,9 @@ func (c *ApiClient) UpdateDevice(ctx context.Context, site string, d *Device) (*
 		return nil, err
 	}
 
-	if len(respBody.Data) != 1 {
-		return nil, &NotFoundError{}
+	// Some devices (observed on UDM-Pro) return data:[] on a successful PUT; refetch in that case.
+	if len(respBody.Data) == 0 {
+		return c.getDevice(ctx, site, d.MAC)
 	}
 
 	res := respBody.Data[0]

--- a/unifi/device.go
+++ b/unifi/device.go
@@ -239,6 +239,11 @@ func (c *ApiClient) UpdateDevice(ctx context.Context, site string, d *Device) (*
 		return nil, fmt.Errorf("failed to create device diff: %w", err)
 	}
 
+	// Empty-body PUT can return an empty data array; skip to avoid a spurious NotFoundError.
+	if len(patch) == 0 {
+		return existing, nil
+	}
+
 	err = c.do(
 		ctx,
 		"PUT",
@@ -312,7 +317,8 @@ func getDiff[T any](original, target *T, skipFields ...string) (map[string]any, 
 
 // getDeviceDiff compares two Device objects and returns a map containing only changed fields.
 func getDeviceDiff(original, target *Device) (map[string]any, error) {
-	return getDiff(original, target, "_id", "site_id")
+	// "state" is the controller-managed operational state; PUTting it back rejects with InvalidPayload.
+	return getDiff(original, target, "_id", "site_id", "state")
 }
 
 // deepEqualJSON compares two values for deep equality by comparing their JSON representations.


### PR DESCRIPTION
…UnmarshalJSON

UniFi controllers send DeviceRadioTable.tx_power and channel as either strings ("auto") or JSON numbers (e.g. 18, 6). The existing custom UnmarshalJSON on DeviceRadioTable coerces the other numeric-or-string fields (antenna_gain, ht, maxsta, etc.) via *types.Number, but tx_power and channel were omitted from the aux struct, so numeric values fell through to the embedded *Alias and failed with:

  json: cannot unmarshal number into Go struct field
  .Alias.tx_power of type string
  json: cannot unmarshal number into Go struct field
  .Alias.channel of type string

This broke `terraform import unifi_device.*` on any controller emitting numeric values for these fields.

Add TxPower and Channel to the aux struct with post-unmarshal conversion that mirrors the existing AntennaGain pattern (and matches what ChannelPlanRadioTable already does for the same fields). Also extend the generator (cmd/fields/main.go) so future regenerations include this conversion.