### PR TITLE
bug: Fix numeric device radio channel

### DIFF
--- a/unifi/device.generated.go
+++ b/unifi/device.generated.go
@@ -879,6 +879,7 @@ func (dst *DeviceRadioTable) UnmarshalJSON(b []byte) error {
 		AntennaID           *types.Number `json:"antenna_id"`
 		AssistedRoamingRssi *types.Number `json:"assisted_roaming_rssi"`
 		Ht                  *types.Number `json:"ht"`
+		Channel             *types.Number `json:"channel"`
 		Maxsta              *types.Number `json:"maxsta"`
 		MinRssi             *types.Number `json:"min_rssi"`
 		SensLevel           *types.Number `json:"sens_level"`
@@ -891,6 +892,9 @@ func (dst *DeviceRadioTable) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, &aux)
 	if err != nil {
 		return fmt.Errorf("unable to unmarshal alias: %w", err)
+	}
+	if aux.Channel != nil {
+		dst.Channel = aux.Channel.String()
 	}
 	if aux.AntennaGain != nil {
 		if val, err := aux.AntennaGain.Int64(); err == nil {

--- a/unifi/device_test.go
+++ b/unifi/device_test.go
@@ -1,0 +1,31 @@
+package unifi_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/ubiquiti-community/go-unifi/unifi"
+)
+
+func TestDeviceRadioTableUnmarshalJSONChannel(t *testing.T) {
+	for name, tc := range map[string]struct {
+		json    string
+		channel string
+	}{
+		"numeric channel":        {json: `{ "channel": 1 }`, channel: "1"},
+		"string numeric channel": {json: `{ "channel": "36" }`, channel: "36"},
+		"auto channel":           {json: `{ "channel": "auto" }`, channel: "auto"},
+		"empty channel":          {json: `{ "channel": "" }`, channel: ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var actual unifi.DeviceRadioTable
+			if err := json.Unmarshal([]byte(tc.json), &actual); err != nil {
+				t.Fatal(err)
+			}
+
+			if actual.Channel != tc.channel {
+				t.Fatalf("channel = %q, want %q", actual.Channel, tc.channel)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why
UniFi Network can return numeric JSON for DeviceRadioTable.channel. The SDK currently expects a string, so device reads can fail during refresh before callers can handle the response.

## Summary
- Accept numeric and string JSON values for DeviceRadioTable.channel
- Add regression coverage for numeric, string, auto, and empty channel values

References ubiquiti-community/go-unifi#19.