### PR TITLE
bug: Omit empty WLAN group ID

### DIFF
--- a/cmd/fields/main.go
+++ b/cmd/fields/main.go
@@ -213,7 +213,7 @@ func NewResource(structName string, resourcePath string) *ResourceInfo {
 		baseType.Fields[" DisplayName"] = NewFieldInfo("DisplayName", "display_name", fields.String, "non-generated field", true, false, false, "")
 	case resource.StructName == "WLAN":
 		// this field removed in v6, retaining for backwards compatibility
-		baseType.Fields["WLANGroupID"] = NewFieldInfo("WLANGroupID", "wlangroup_id", fields.String, "", false, false, false, "")
+		baseType.Fields["WLANGroupID"] = NewFieldInfo("WLANGroupID", "wlangroup_id", fields.String, "", true, false, false, "")
 	case resource.StructName == "BGPConfig":
 		resource.ResourcePath = "bgp/config"
 	}

--- a/unifi/wlan.generated.go
+++ b/unifi/wlan.generated.go
@@ -119,7 +119,7 @@ type WLAN struct {
 	WEPIDX                      *int64                     `json:"wep_idx,omitempty"`    // [1-4]
 	WLANBand                    string                     `json:"wlan_band,omitempty"`  // 2g|5g|both
 	WLANBands                   []string                   `json:"wlan_bands,omitempty"` // 2g|5g|6g
-	WLANGroupID                 string                     `json:"wlangroup_id"`
+	WLANGroupID                 string                     `json:"wlangroup_id,omitempty"`
 	WPA3Enhanced192             bool                       `json:"wpa3_enhanced_192"`
 	WPA3FastRoaming             bool                       `json:"wpa3_fast_roaming"`
 	WPA3Support                 bool                       `json:"wpa3_support"`

--- a/unifi/wlan_test.go
+++ b/unifi/wlan_test.go
@@ -1,0 +1,44 @@
+package unifi_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/ubiquiti-community/go-unifi/unifi"
+)
+
+func TestWLANMarshalJSONOmitEmptyWLANGroupID(t *testing.T) {
+	actual, err := json.Marshal(&unifi.WLAN{Name: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(actual) == "{}" {
+		t.Fatal("expected non-empty JSON payload")
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(actual, &payload); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := payload["wlangroup_id"]; ok {
+		t.Fatalf("wlangroup_id was serialized for empty value: %s", actual)
+	}
+}
+
+func TestWLANMarshalJSONIncludesWLANGroupID(t *testing.T) {
+	actual, err := json.Marshal(&unifi.WLAN{Name: "test", WLANGroupID: "default"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(actual, &payload); err != nil {
+		t.Fatal(err)
+	}
+
+	if payload["wlangroup_id"] != "default" {
+		t.Fatalf("wlangroup_id = %#v, want %q; payload: %s", payload["wlangroup_id"], "default", actual)
+	}
+}


### PR DESCRIPTION
## Summary
- Omit WLANGroupID when it is empty
- Add regression coverage for empty and non-empty wlangroup_id payloads

References ubiquiti-community/terraform-provider-unifi#176.