### PR TITLE
feat: add WireGuard peer management

### DIFF
--- a/unifi/wireguard_peer.go
+++ b/unifi/wireguard_peer.go
@@ -1,0 +1,97 @@
+package unifi
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// This is a v2 API object, manually coded.
+//
+// WireGuard peers ("clients" in the UI) of a WireGuard server network
+// (vpn_type=wireguard-server). The controller only exposes batch
+// create/update/delete endpoints, so single-peer CRUD wraps those.
+
+type WireGuardPeer struct {
+	ID        string `json:"_id,omitempty"`
+	NetworkID string `json:"network_id,omitempty"`
+
+	Name        string   `json:"name"`
+	InterfaceIP string   `json:"interface_ip"`
+	PublicKey   string   `json:"public_key"`
+	AllowedIPs  []string `json:"allowed_ips"`
+}
+
+func (c *ApiClient) wireGuardPeersPath(site, networkID string) string {
+	return fmt.Sprintf("v2/api/site/%s/wireguard/%s/users", site, networkID)
+}
+
+func (c *ApiClient) ListWireGuardPeers(ctx context.Context, site, networkID string) ([]WireGuardPeer, error) {
+	var respBody []WireGuardPeer
+
+	err := c.do(ctx, http.MethodGet, c.wireGuardPeersPath(site, networkID), nil, &respBody,
+		map[string]string{"networkId": networkID})
+	if err != nil {
+		return nil, err
+	}
+
+	return respBody, nil
+}
+
+// GetWireGuardPeer fetches a single peer by ID. The controller has no
+// single-peer endpoint, so this lists and filters.
+func (c *ApiClient) GetWireGuardPeer(ctx context.Context, site, networkID, id string) (*WireGuardPeer, error) {
+	peers, err := c.ListWireGuardPeers(ctx, site, networkID)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range peers {
+		if peers[i].ID == id {
+			return &peers[i], nil
+		}
+	}
+
+	return nil, &NotFoundError{Type: "wireguard_peer", Attr: "_id", Value: id}
+}
+
+func (c *ApiClient) CreateWireGuardPeer(ctx context.Context, site, networkID string, d *WireGuardPeer) (*WireGuardPeer, error) {
+	var respBody []WireGuardPeer
+	d.ID = ""
+	if d.AllowedIPs == nil {
+		d.AllowedIPs = []string{}
+	}
+
+	err := c.do(ctx, http.MethodPost, c.wireGuardPeersPath(site, networkID)+"/batch", []*WireGuardPeer{d}, &respBody)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(respBody) != 1 {
+		return nil, &NotFoundError{Type: "wireguard_peer"}
+	}
+
+	return &respBody[0], nil
+}
+
+func (c *ApiClient) UpdateWireGuardPeer(ctx context.Context, site, networkID string, d *WireGuardPeer) (*WireGuardPeer, error) {
+	var respBody []WireGuardPeer
+	if d.AllowedIPs == nil {
+		d.AllowedIPs = []string{}
+	}
+
+	err := c.do(ctx, http.MethodPut, c.wireGuardPeersPath(site, networkID)+"/batch", []*WireGuardPeer{d}, &respBody)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(respBody) != 1 {
+		return nil, &NotFoundError{Type: "wireguard_peer", Attr: "_id", Value: d.ID}
+	}
+
+	return &respBody[0], nil
+}
+
+func (c *ApiClient) DeleteWireGuardPeer(ctx context.Context, site, networkID, id string) error {
+	return c.do(ctx, http.MethodPost, c.wireGuardPeersPath(site, networkID)+"/batch_delete", []string{id}, nil)
+}

--- a/unifi/wireguard_peer_test.go
+++ b/unifi/wireguard_peer_test.go
@@ -1,0 +1,50 @@
+package unifi_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/ubiquiti-community/go-unifi/unifi"
+)
+
+func TestWireGuardPeerMarshalJSON(t *testing.T) {
+	peer := unifi.WireGuardPeer{
+		Name:        "test-peer",
+		InterfaceIP: "192.0.2.10",
+		PublicKey:   "ZmFrZS10ZXN0LXdpcmVndWFyZC1wdWJrZXkAAAAAAAA=",
+		AllowedIPs:  []string{},
+	}
+
+	actual, err := json.Marshal(&peer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.JSONEq(t,
+		`{"name":"test-peer","interface_ip":"192.0.2.10","public_key":"ZmFrZS10ZXN0LXdpcmVndWFyZC1wdWJrZXkAAAAAAAA=","allowed_ips":[]}`,
+		string(actual))
+}
+
+func TestWireGuardPeerUnmarshalJSON(t *testing.T) {
+	// shape returned by the controller (v2 wireguard users API)
+	raw := `{
+		"_id": "000000000000000000000001",
+		"network_id": "000000000000000000000002",
+		"name": "test-peer",
+		"interface_ip": "192.0.2.10",
+		"public_key": "ZmFrZS10ZXN0LXdpcmVndWFyZC1wdWJrZXkAAAAAAAA=",
+		"allowed_ips": ["198.51.100.0/24"]
+	}`
+
+	var peer unifi.WireGuardPeer
+	if err := json.Unmarshal([]byte(raw), &peer); err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "000000000000000000000001", peer.ID)
+	assert.Equal(t, "000000000000000000000002", peer.NetworkID)
+	assert.Equal(t, "test-peer", peer.Name)
+	assert.Equal(t, "192.0.2.10", peer.InterfaceIP)
+	assert.Equal(t, "ZmFrZS10ZXN0LXdpcmVndWFyZC1wdWJrZXkAAAAAAAA=", peer.PublicKey)
+	assert.Equal(t, []string{"198.51.100.0/24"}, peer.AllowedIPs)
+}


### PR DESCRIPTION
Adds CRUD support for WireGuard peers (the "clients" listed under a WireGuard VPN server in the Network UI).

WireGuard servers are already modeled as `Network` objects (`vpn_type=wireguard-server`), but their peers live behind a separate, batch-oriented v2 endpoint that isn't covered by the code-generated specs:

```
GET  v2/api/site/{site}/wireguard/{networkID}/users?networkId={networkID}
POST v2/api/site/{site}/wireguard/{networkID}/users/batch         (create)
PUT  v2/api/site/{site}/wireguard/{networkID}/users/batch         (update by _id)
POST v2/api/site/{site}/wireguard/{networkID}/users/batch_delete  ([_id, ...])
```

## Changes
- `unifi/wireguard_peer.go` — hand-written `WireGuardPeer` type and `List/Get/Create/Update/Delete` methods, following the existing v2 hand-coded pattern (`network_members_group.go`, `ap_group.go`). Single-peer CRUD wraps the batch endpoints; `Get` lists and filters by `_id` since the controller has no single-peer GET.
- `unifi/wireguard_peer_test.go` — JSON marshal/unmarshal round-trip tests.

## Testing
Verified end to end against a live UDM controller (UniFi Network 10.4.57, UniFi OS 5.1.15): create/get/update/delete round-trips, plus a working tunnel to a real peer. Used by a forthcoming `unifi_wireguard_peer` resource in terraform-provider-unifi.

Note: `interface_ip` must fall within the WireGuard server's configured subnet or the controller returns `api.err.UserIpDoesNotBelongToNetwork`.