### PR TITLE
feat(types): tolerate string-encoded booleans (dhcpd_enabled, client blocked)

### DIFF
--- a/cmd/fields/main.go
+++ b/cmd/fields/main.go
@@ -476,6 +476,15 @@ func main() {
 						f.CustomUnmarshalType = "*bool"
 						f.CustomUnmarshalFunc = "emptyBoolToTrue"
 					}
+				case "DHCPDEnabled":
+					// Some controllers (UniFi Network 10.x) return "true"/"false"
+					// as JSON strings for this flag, which breaks a plain bool.
+					// Decode through the tolerant types.Bool. See
+					// terraform-provider-unifi #65.
+					if f.FieldType == fields.Bool {
+						f.CustomUnmarshalType = "*types.Bool"
+						f.CustomUnmarshalFunc = "boolValue"
+					}
 				case "IPSecEspLifetime", "IPSecIkeLifetime":
 					f.FieldType = fields.Int
 					f.IsPointer = true
@@ -545,6 +554,11 @@ func main() {
 				case "Blocked":
 					f.FieldType = fields.Bool
 					f.IsPointer = true
+					// Some controllers return "true"/"false" as JSON strings
+					// for this flag, which breaks a plain *bool. Decode through
+					// the tolerant types.Bool. See terraform-provider-unifi #132.
+					f.CustomUnmarshalType = "*types.Bool"
+					f.CustomUnmarshalFunc = "boolPtrValue"
 				case "VirtualNetworkOverrideEnabled":
 					f.FieldType = fields.Bool
 					f.IsPointer = true

--- a/unifi/client.generated.go
+++ b/unifi/client.generated.go
@@ -57,6 +57,8 @@ type Client struct {
 func (dst *Client) UnmarshalJSON(b []byte) error {
 	type Alias Client
 	aux := &struct {
+		Blocked *types.Bool `json:"blocked"`
+
 		*Alias
 	}{
 		Alias: (*Alias)(dst),
@@ -66,6 +68,7 @@ func (dst *Client) UnmarshalJSON(b []byte) error {
 	if err != nil {
 		return fmt.Errorf("unable to unmarshal alias: %w", err)
 	}
+	dst.Blocked = boolPtrValue(aux.Blocked)
 
 	return nil
 }

--- a/unifi/json.go
+++ b/unifi/json.go
@@ -1,8 +1,30 @@
 package unifi
 
+import "github.com/ubiquiti-community/go-unifi/unifi/types"
+
 func emptyBoolToTrue(b *bool) bool {
 	if b == nil {
 		return true
 	}
 	return *b
+}
+
+// boolValue resolves a tolerant *types.Bool (which accepts both native and
+// string-encoded JSON booleans) into a plain bool, defaulting to false when the
+// field is absent.
+func boolValue(b *types.Bool) bool {
+	if b == nil {
+		return false
+	}
+	return b.Bool()
+}
+
+// boolPtrValue resolves a tolerant *types.Bool into a *bool, preserving the
+// distinction between an absent field (nil) and an explicit false.
+func boolPtrValue(b *types.Bool) *bool {
+	if b == nil {
+		return nil
+	}
+	v := b.Bool()
+	return &v
 }

--- a/unifi/network.generated.go
+++ b/unifi/network.generated.go
@@ -286,6 +286,7 @@ type Network struct {
 func (dst *Network) UnmarshalJSON(b []byte) error {
 	type Alias Network
 	aux := &struct {
+		DHCPDEnabled                   *types.Bool   `json:"dhcpd_enabled"`
 		DHCPDLeaseTime                 *types.Number `json:"dhcpd_leasetime"`
 		DHCPDTimeOffset                *types.Number `json:"dhcpd_time_offset"`
 		DHCPDV6LeaseTime               *types.Number `json:"dhcpdv6_leasetime"`
@@ -330,6 +331,7 @@ func (dst *Network) UnmarshalJSON(b []byte) error {
 	if err != nil {
 		return fmt.Errorf("unable to unmarshal alias: %w", err)
 	}
+	dst.DHCPDEnabled = boolValue(aux.DHCPDEnabled)
 	if aux.DHCPDLeaseTime != nil {
 		if val, err := aux.DHCPDLeaseTime.Int64(); err == nil {
 			dst.DHCPDLeaseTime = &val

--- a/unifi/stringable_bool_test.go
+++ b/unifi/stringable_bool_test.go
@@ -1,0 +1,65 @@
+package unifi
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestNetworkDHCPDEnabledTolerantUnmarshal verifies that Network.DHCPDEnabled
+// decodes whether the controller sends a native JSON boolean or a quoted
+// string (terraform-provider-unifi #65).
+func TestNetworkDHCPDEnabledTolerantUnmarshal(t *testing.T) {
+	cases := map[string]bool{
+		`{"dhcpd_enabled": true}`:    true,
+		`{"dhcpd_enabled": false}`:   false,
+		`{"dhcpd_enabled": "true"}`:  true,
+		`{"dhcpd_enabled": "false"}`: false,
+		`{"dhcpd_enabled": ""}`:      false,
+		`{}`:                         false,
+	}
+	for body, want := range cases {
+		var n Network
+		if err := json.Unmarshal([]byte(body), &n); err != nil {
+			t.Errorf("Unmarshal(%s) error: %v", body, err)
+			continue
+		}
+		if n.DHCPDEnabled != want {
+			t.Errorf("Unmarshal(%s): DHCPDEnabled = %v, want %v", body, n.DHCPDEnabled, want)
+		}
+	}
+}
+
+// TestClientBlockedTolerantUnmarshal verifies that Client.Blocked decodes both
+// native and string-encoded booleans, and stays nil when absent
+// (terraform-provider-unifi #132).
+func TestClientBlockedTolerantUnmarshal(t *testing.T) {
+	truthy := []string{`{"blocked": true}`, `{"blocked": "true"}`}
+	for _, body := range truthy {
+		var c Client
+		if err := json.Unmarshal([]byte(body), &c); err != nil {
+			t.Fatalf("Unmarshal(%s) error: %v", body, err)
+		}
+		if c.Blocked == nil || !*c.Blocked {
+			t.Errorf("Unmarshal(%s): Blocked = %v, want true", body, c.Blocked)
+		}
+	}
+
+	falsy := []string{`{"blocked": false}`, `{"blocked": "false"}`, `{"blocked": ""}`}
+	for _, body := range falsy {
+		var c Client
+		if err := json.Unmarshal([]byte(body), &c); err != nil {
+			t.Fatalf("Unmarshal(%s) error: %v", body, err)
+		}
+		if c.Blocked == nil || *c.Blocked {
+			t.Errorf("Unmarshal(%s): Blocked = %v, want false", body, c.Blocked)
+		}
+	}
+
+	var c Client
+	if err := json.Unmarshal([]byte(`{}`), &c); err != nil {
+		t.Fatalf("Unmarshal({}) error: %v", err)
+	}
+	if c.Blocked != nil {
+		t.Errorf("Unmarshal({}): Blocked = %v, want nil", c.Blocked)
+	}
+}

--- a/unifi/types/bool.go
+++ b/unifi/types/bool.go
@@ -1,0 +1,36 @@
+package types
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Bool handles JSON values that the UniFi controller encodes inconsistently as
+// either a native boolean (true/false) or a quoted string ("true"/"false").
+// Some controllers (observed on UniFi Network 10.x) return string-encoded
+// booleans for fields such as dhcpd_enabled or a client's blocked flag, which
+// makes a plain bool field fail to unmarshal. An empty string is treated as
+// false.
+type Bool bool
+
+func (b *Bool) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+	s := strings.Trim(string(data), `"`)
+	if s == "" || s == "null" {
+		*b = false
+		return nil
+	}
+	v, err := strconv.ParseBool(s)
+	if err != nil {
+		return err
+	}
+	*b = Bool(v)
+	return nil
+}
+
+// Bool returns the underlying boolean value.
+func (b Bool) Bool() bool {
+	return bool(b)
+}


### PR DESCRIPTION
Some UniFi controllers (observed on Network 10.x) encode certain boolean fields as JSON **strings** (`"true"`/`"false"`) instead of native booleans. A plain `bool` / `*bool` field then fails to unmarshal, breaking reads in the Terraform provider:

- `Network.dhcpd_enabled` → ubiquiti-community/terraform-provider-unifi#65 (`cannot unmarshal string into ... dhcpd_enabled (bool)`)
- `Client.blocked` → ubiquiti-community/terraform-provider-unifi#132 (`unifi_client` read fails)

## Change

- New tolerant **`types.Bool`** (mirroring the existing `types.Number`): accepts native booleans, quoted strings, and empty strings.
- `boolValue` / `boolPtrValue` helpers in `json.go`.
- Wired both fields through it in the **generator** (`cmd/fields` `FieldProcessor` for `Network`/`DHCPDEnabled` and `Client`/`Blocked`), and applied the same change to the generated code.
- Unit tests covering native + string-encoded booleans for both fields.

## Note on the generated files

I edited `network.generated.go` / `client.generated.go` **by hand** to match the generator change, because the pinned source `.deb` (UniFi 9.5.21) is no longer downloadable from `dl.ui.com` in my environment (403). Re-running `go generate ./...` on a machine with access should produce an identical diff — please regenerate to confirm before merging.

`go build`, `go vet`, and the full `go test ./...` suite pass.