### PR TITLE
feat(network): emit full IPv6 and DHCPv6 fields in marshalers

### DIFF
--- a/unifi/network_encode.go
+++ b/unifi/network_encode.go
@@ -113,12 +113,26 @@ func (n *Network) marshalCorporate() ([]byte, error) {
 		DHCPRelayServers []string `json:"dhcp_relay_servers"`
 
 		// IPv6
-		IPV6InterfaceType     *string `json:"ipv6_interface_type,omitempty"`
-		IPV6SettingPreference *string `json:"ipv6_setting_preference,omitempty"`
-		IPV6RaPriority        *string `json:"ipv6_ra_priority,omitempty"`
+		IPV6InterfaceType         *string `json:"ipv6_interface_type,omitempty"`
+		IPV6SettingPreference     *string `json:"ipv6_setting_preference,omitempty"`
+		IPV6RaPriority            *string `json:"ipv6_ra_priority,omitempty"`
+		IPV6Subnet                *string `json:"ipv6_subnet,omitempty"`
+		IPV6RaEnabled             bool    `json:"ipv6_ra_enabled"`
+		IPV6RaPreferredLifetime   *int64  `json:"ipv6_ra_preferred_lifetime,omitempty"`
+		IPV6RaValidLifetime       *int64  `json:"ipv6_ra_valid_lifetime,omitempty"`
+		IPV6PDInterface           *string `json:"ipv6_pd_interface,omitempty"`
+		IPV6PDPrefixid            string  `json:"ipv6_pd_prefixid"`
+		IPV6PDStart               *string `json:"ipv6_pd_start,omitempty"`
+		IPV6PDStop                *string `json:"ipv6_pd_stop,omitempty"`
+		IPV6PDAutoPrefixidEnabled bool    `json:"ipv6_pd_auto_prefixid_enabled"`
 
 		// DHCPv6
-		DHCPDV6DNSAuto    bool    `json:"dhcpdv6_dns_auto,omitempty"`
+		DHCPDV6Enabled    bool    `json:"dhcpdv6_enabled"`
+		DHCPDV6DNSAuto    bool    `json:"dhcpdv6_dns_auto"`
+		DHCPDV6DNS1       *string `json:"dhcpdv6_dns_1,omitempty"`
+		DHCPDV6DNS2       *string `json:"dhcpdv6_dns_2,omitempty"`
+		DHCPDV6DNS3       *string `json:"dhcpdv6_dns_3,omitempty"`
+		DHCPDV6DNS4       *string `json:"dhcpdv6_dns_4,omitempty"`
 		DHCPDV6AllowSlaac bool    `json:"dhcpdv6_allow_slaac,omitempty"`
 		DHCPDV6Start      *string `json:"dhcpdv6_start,omitempty"`
 		DHCPDV6Stop       *string `json:"dhcpdv6_stop,omitempty"`
@@ -184,12 +198,26 @@ func (n *Network) marshalCorporate() ([]byte, error) {
 		DHCPRelayServers: orEmptySlice(n.RemoteVPNSubnets),
 
 		// IPv6
-		IPV6InterfaceType:     valueOrDefault(n.IPV6InterfaceType, "none"),
-		IPV6SettingPreference: n.IPV6SettingPreference,
-		IPV6RaPriority:        n.IPV6RaPriority,
+		IPV6InterfaceType:         valueOrDefault(n.IPV6InterfaceType, "none"),
+		IPV6SettingPreference:     n.IPV6SettingPreference,
+		IPV6RaPriority:            n.IPV6RaPriority,
+		IPV6Subnet:                n.IPV6Subnet,
+		IPV6RaEnabled:             n.IPV6RaEnabled,
+		IPV6RaPreferredLifetime:   n.IPV6RaPreferredLifetime,
+		IPV6RaValidLifetime:       n.IPV6RaValidLifetime,
+		IPV6PDInterface:           n.IPV6PDInterface,
+		IPV6PDPrefixid:            n.IPV6PDPrefixid,
+		IPV6PDStart:               n.IPV6PDStart,
+		IPV6PDStop:                n.IPV6PDStop,
+		IPV6PDAutoPrefixidEnabled: n.IPV6PDAutoPrefixidEnabled,
 
 		// DHCPv6
+		DHCPDV6Enabled:    n.DHCPDV6Enabled,
 		DHCPDV6DNSAuto:    n.DHCPDV6DNSAuto,
+		DHCPDV6DNS1:       n.DHCPDV6DNS1,
+		DHCPDV6DNS2:       n.DHCPDV6DNS2,
+		DHCPDV6DNS3:       n.DHCPDV6DNS3,
+		DHCPDV6DNS4:       n.DHCPDV6DNS4,
 		DHCPDV6AllowSlaac: n.DHCPDV6AllowSlaac,
 		DHCPDV6Start:      n.DHCPDV6Start,
 		DHCPDV6Stop:       n.DHCPDV6Stop,
@@ -321,12 +349,26 @@ func (n *Network) marshalGuest() ([]byte, error) {
 		DHCPRelayServers []string `json:"dhcp_relay_servers"`
 
 		// IPv6
-		IPV6InterfaceType     *string `json:"ipv6_interface_type,omitempty"`
-		IPV6SettingPreference *string `json:"ipv6_setting_preference,omitempty"`
-		IPV6RaPriority        *string `json:"ipv6_ra_priority,omitempty"`
+		IPV6InterfaceType         *string `json:"ipv6_interface_type,omitempty"`
+		IPV6SettingPreference     *string `json:"ipv6_setting_preference,omitempty"`
+		IPV6RaPriority            *string `json:"ipv6_ra_priority,omitempty"`
+		IPV6Subnet                *string `json:"ipv6_subnet,omitempty"`
+		IPV6RaEnabled             bool    `json:"ipv6_ra_enabled"`
+		IPV6RaPreferredLifetime   *int64  `json:"ipv6_ra_preferred_lifetime,omitempty"`
+		IPV6RaValidLifetime       *int64  `json:"ipv6_ra_valid_lifetime,omitempty"`
+		IPV6PDInterface           *string `json:"ipv6_pd_interface,omitempty"`
+		IPV6PDPrefixid            string  `json:"ipv6_pd_prefixid"`
+		IPV6PDStart               *string `json:"ipv6_pd_start,omitempty"`
+		IPV6PDStop                *string `json:"ipv6_pd_stop,omitempty"`
+		IPV6PDAutoPrefixidEnabled bool    `json:"ipv6_pd_auto_prefixid_enabled"`
 
 		// DHCPv6
-		DHCPDV6DNSAuto    bool    `json:"dhcpdv6_dns_auto,omitempty"`
+		DHCPDV6Enabled    bool    `json:"dhcpdv6_enabled"`
+		DHCPDV6DNSAuto    bool    `json:"dhcpdv6_dns_auto"`
+		DHCPDV6DNS1       *string `json:"dhcpdv6_dns_1,omitempty"`
+		DHCPDV6DNS2       *string `json:"dhcpdv6_dns_2,omitempty"`
+		DHCPDV6DNS3       *string `json:"dhcpdv6_dns_3,omitempty"`
+		DHCPDV6DNS4       *string `json:"dhcpdv6_dns_4,omitempty"`
 		DHCPDV6AllowSlaac bool    `json:"dhcpdv6_allow_slaac,omitempty"`
 		DHCPDV6Start      *string `json:"dhcpdv6_start,omitempty"`
 		DHCPDV6Stop       *string `json:"dhcpdv6_stop,omitempty"`
@@ -392,12 +434,26 @@ func (n *Network) marshalGuest() ([]byte, error) {
 		DHCPRelayServers: orEmptySlice(n.DHCPRelayServers),
 
 		// IPv6
-		IPV6InterfaceType:     valueOrDefault(n.IPV6InterfaceType, "none"),
-		IPV6SettingPreference: n.IPV6SettingPreference,
-		IPV6RaPriority:        n.IPV6RaPriority,
+		IPV6InterfaceType:         valueOrDefault(n.IPV6InterfaceType, "none"),
+		IPV6SettingPreference:     n.IPV6SettingPreference,
+		IPV6RaPriority:            n.IPV6RaPriority,
+		IPV6Subnet:                n.IPV6Subnet,
+		IPV6RaEnabled:             n.IPV6RaEnabled,
+		IPV6RaPreferredLifetime:   n.IPV6RaPreferredLifetime,
+		IPV6RaValidLifetime:       n.IPV6RaValidLifetime,
+		IPV6PDInterface:           n.IPV6PDInterface,
+		IPV6PDPrefixid:            n.IPV6PDPrefixid,
+		IPV6PDStart:               n.IPV6PDStart,
+		IPV6PDStop:                n.IPV6PDStop,
+		IPV6PDAutoPrefixidEnabled: n.IPV6PDAutoPrefixidEnabled,
 
 		// DHCPv6
+		DHCPDV6Enabled:    n.DHCPDV6Enabled,
 		DHCPDV6DNSAuto:    n.DHCPDV6DNSAuto,
+		DHCPDV6DNS1:       n.DHCPDV6DNS1,
+		DHCPDV6DNS2:       n.DHCPDV6DNS2,
+		DHCPDV6DNS3:       n.DHCPDV6DNS3,
+		DHCPDV6DNS4:       n.DHCPDV6DNS4,
 		DHCPDV6AllowSlaac: n.DHCPDV6AllowSlaac,
 		DHCPDV6Start:      n.DHCPDV6Start,
 		DHCPDV6Stop:       n.DHCPDV6Stop,


### PR DESCRIPTION
## Context
`marshalCorporate`/`marshalGuest` only emitted `ipv6_interface_type` and `ipv6_ra_priority`, silently dropping every other IPv6 field a caller set on the `Network` struct. As a result:
- A network with a static IPv6 subnet + Router Advertisement is rejected by the controller with `api.err.InvalidSlaacPrefixLength` — the prefix (`ipv6_subnet`) and RA flags (`ipv6_ra_enabled`, lifetimes) never reach it.
- DHCPv6 server settings (`dhcpdv6_enabled`, `dhcpdv6_dns_*`) are ignored, so the server silently stays disabled.

Confirmed against a real UDM (UniFi OS 10.x): before this change network create fails / drops the fields; after, the IPv6 config is stored and round-trips cleanly.

## Changes
Emit from both `marshalCorporate` and `marshalGuest`:
- IPv6: `ipv6_subnet`, `ipv6_ra_enabled`, `ipv6_ra_preferred_lifetime`, `ipv6_ra_valid_lifetime`, `ipv6_pd_interface`, `ipv6_pd_prefixid`, `ipv6_pd_start`, `ipv6_pd_stop`, `ipv6_pd_auto_prefixid_enabled`.
- DHCPv6: `dhcpdv6_enabled`, `dhcpdv6_dns_1..4` (and drop `omitempty` from `dhcpdv6_dns_auto` so an explicit `false` is sent).

Unblocks the IPv6 network support in terraform-provider-unifi#158.

## Tests
`go build`, `go vet`, and `go test ./unifi/` pass. Validated end-to-end with the provider against a real UDM and the dockerized acceptance suite.