### PR TITLE
fix(device): accept numeric channel/tx_power in radio_table

### DIFF
--- a/cmd/fields/api.go.tmpl
+++ b/cmd/fields/api.go.tmpl
@@ -32,13 +32,13 @@
 		}
 	}
 				{{- else }}
-	if val, err := aux.{{ .FieldName }}.Int64(); err == nil {
 		{{- if eq .FieldType "string" }}
-		dst.{{ .FieldName }} = strconv.FormatInt(val, 10)
+	dst.{{ .FieldName }} = aux.{{ .FieldName }}.String()
 		{{- else }}
+	if val, err := aux.{{ .FieldName }}.Int64(); err == nil {
 		dst.{{ .FieldName }} = val
-		{{- end }}
 	}
+		{{- end }}
 				{{- end }}
 			{{- end }}
 		{{- else }}

--- a/cmd/fields/main.go
+++ b/cmd/fields/main.go
@@ -458,6 +458,12 @@ func main() {
 					// Field within DeviceRadioTable nested type
 					f.CustomUnmarshalType = "types.Number"
 					f.CustomUnmarshalFunc = "types.ToInt64Pointer"
+				case "Channel", "TxPower":
+					// String fields in DeviceRadioTable that newer controllers
+					// (UniFi 10.x) return as numbers; accept either form.
+					if f.FieldType == fields.String {
+						f.CustomUnmarshalType = fields.Number
+					}
 				}
 
 				f.OmitEmpty = true

--- a/unifi/channel_plan.generated.go
+++ b/unifi/channel_plan.generated.go
@@ -78,12 +78,8 @@ func (dst *ChannelPlanRadioTable) UnmarshalJSON(b []byte) error {
 	if err != nil {
 		return fmt.Errorf("unable to unmarshal alias: %w", err)
 	}
-	if val, err := aux.Channel.Int64(); err == nil {
-		dst.Channel = strconv.FormatInt(val, 10)
-	}
-	if val, err := aux.TxPower.Int64(); err == nil {
-		dst.TxPower = strconv.FormatInt(val, 10)
-	}
+	dst.Channel = aux.Channel.String()
+	dst.TxPower = aux.TxPower.String()
 	if aux.Width != nil {
 		if val, err := aux.Width.Int64(); err == nil {
 			dst.Width = &val

--- a/unifi/device.generated.go
+++ b/unifi/device.generated.go
@@ -878,10 +878,12 @@ func (dst *DeviceRadioTable) UnmarshalJSON(b []byte) error {
 		AntennaGain         *types.Number `json:"antenna_gain"`
 		AntennaID           *types.Number `json:"antenna_id"`
 		AssistedRoamingRssi *types.Number `json:"assisted_roaming_rssi"`
+		Channel             types.Number  `json:"channel"`
 		Ht                  *types.Number `json:"ht"`
 		Maxsta              *types.Number `json:"maxsta"`
 		MinRssi             *types.Number `json:"min_rssi"`
 		SensLevel           *types.Number `json:"sens_level"`
+		TxPower             types.Number  `json:"tx_power"`
 
 		*Alias
 	}{
@@ -916,6 +918,7 @@ func (dst *DeviceRadioTable) UnmarshalJSON(b []byte) error {
 			dst.AssistedRoamingRssi = &zero
 		}
 	}
+	dst.Channel = aux.Channel.String()
 	dst.Ht = types.ToInt64Pointer(aux.Ht)
 	if aux.Maxsta != nil {
 		if val, err := aux.Maxsta.Int64(); err == nil {
@@ -941,6 +944,7 @@ func (dst *DeviceRadioTable) UnmarshalJSON(b []byte) error {
 			dst.SensLevel = &zero
 		}
 	}
+	dst.TxPower = aux.TxPower.String()
 
 	return nil
 }

--- a/unifi/device_radio_table_test.go
+++ b/unifi/device_radio_table_test.go
@@ -1,0 +1,59 @@
+package unifi
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Regression test for ubiquiti-community/terraform-provider-unifi#112:
+// UniFi 10.x controllers return radio_table channel/tx_power as JSON numbers,
+// while older ones (and the schema) use strings such as "auto". The
+// DeviceRadioTable unmarshaler must accept either form for these string fields.
+func TestDeviceRadioTableUnmarshalChannelTxPower(t *testing.T) {
+	tests := []struct {
+		name        string
+		raw         string
+		wantChannel string
+		wantTxPower string
+	}{
+		{
+			name:        "numeric channel and tx_power (UniFi 10.x)",
+			raw:         `{"radio":"na","channel":36,"tx_power":23}`,
+			wantChannel: "36",
+			wantTxPower: "23",
+		},
+		{
+			name:        "string auto (older controllers)",
+			raw:         `{"radio":"ng","channel":"auto","tx_power":"auto"}`,
+			wantChannel: "auto",
+			wantTxPower: "auto",
+		},
+		{
+			name:        "numeric string channel",
+			raw:         `{"radio":"na","channel":"149","tx_power":"high"}`,
+			wantChannel: "149",
+			wantTxPower: "high",
+		},
+		{
+			name:        "fractional channel (6GHz)",
+			raw:         `{"radio":"6e","channel":1.5}`,
+			wantChannel: "1.5",
+			wantTxPower: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var rt DeviceRadioTable
+			if err := json.Unmarshal([]byte(tc.raw), &rt); err != nil {
+				t.Fatalf("unmarshal failed: %v", err)
+			}
+			if rt.Channel != tc.wantChannel {
+				t.Errorf("Channel = %q, want %q", rt.Channel, tc.wantChannel)
+			}
+			if rt.TxPower != tc.wantTxPower {
+				t.Errorf("TxPower = %q, want %q", rt.TxPower, tc.wantTxPower)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Context
On UniFi Network 10.x, `GET stat/device` returns `radio_table` `channel` and `tx_power` as JSON **numbers**, whereas the schema (and older controllers) use **strings** like `"auto"`. `DeviceRadioTable` typed both as plain `string`, so `UnmarshalJSON` fails with:

```
cannot unmarshal number into Go struct field .Alias.channel of type string
```

This breaks every device read/import on recent controllers — see ubiquiti-community/terraform-provider-unifi#112 (multiple reporters, UDR7 / Network 10.x).

## Changes
- **Generator** (`cmd/fields/main.go`): add `Channel`/`TxPower` to the `Device` field processor so they use the flexible `types.Number` unmarshal type — same treatment `ChannelPlan` already has.
- **Template** (`cmd/fields/api.go.tmpl`): for `string` fields backed by `types.Number`, convert with `.String()` instead of `Int64()`+`FormatInt`. The old path silently dropped non-numeric values (`"auto"`) and fractional channels (`"1.5"`); `.String()` preserves them. This also fixes the same latent loss in `ChannelPlan`.
- Regenerated `device.generated.go` / `channel_plan.generated.go`.
- Added `TestDeviceRadioTableUnmarshalChannelTxPower` covering numeric, `"auto"`, numeric-string and fractional inputs.

## Tests
`go build`, `go vet`, `go test ./unifi/...` pass. New test green.

Fixes the root cause of ubiquiti-community/terraform-provider-unifi#112.