### PR TITLE
fix(firewall-policy): encode source/destination port as string

### DIFF
--- a/unifi/firewall_policy_encode.go
+++ b/unifi/firewall_policy_encode.go
@@ -1,0 +1,46 @@
+package unifi
+
+import (
+	"encoding/json"
+	"strconv"
+)
+
+// The zone-based firewall API (UniFi Network 8.x+) rejects a PUT/POST whose
+// source/destination `port` is encoded as a JSON number. The firmware expects
+// the port as a quoted string (e.g. "161"); decoding already tolerates either
+// form via the generated UnmarshalJSON. These custom marshalers re-encode the
+// port as a string while leaving every other field to the generated layout.
+//
+// The anonymous wrapper places a string `port` at depth 0, which dominates the
+// embedded alias' numeric `port` at depth 1 per encoding/json's field rules, so
+// the numeric field is suppressed. An empty string (nil port) is dropped by
+// omitempty, matching the firmware's expectation when port_matching_type is ANY.
+
+func (s FirewallPolicySource) MarshalJSON() ([]byte, error) {
+	type Alias FirewallPolicySource
+	return json.Marshal(&struct {
+		Port string `json:"port,omitempty"`
+		Alias
+	}{
+		Port:  portToString(s.Port),
+		Alias: Alias(s),
+	})
+}
+
+func (d FirewallPolicyDestination) MarshalJSON() ([]byte, error) {
+	type Alias FirewallPolicyDestination
+	return json.Marshal(&struct {
+		Port string `json:"port,omitempty"`
+		Alias
+	}{
+		Port:  portToString(d.Port),
+		Alias: Alias(d),
+	})
+}
+
+func portToString(p *int64) string {
+	if p == nil {
+		return ""
+	}
+	return strconv.FormatInt(*p, 10)
+}

--- a/unifi/firewall_policy_encode_test.go
+++ b/unifi/firewall_policy_encode_test.go
@@ -1,0 +1,80 @@
+package unifi
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestFirewallPolicyPortMarshalsAsString(t *testing.T) {
+	cases := []struct {
+		name     string
+		port     *int64
+		wantPort string // exact JSON fragment expected, or "" when port must be absent
+	}{
+		{name: "specific port", port: ptrInt64(161), wantPort: `"port":"161"`},
+		{name: "no port", port: nil, wantPort: ""},
+	}
+
+	for _, tc := range cases {
+		t.Run("source/"+tc.name, func(t *testing.T) {
+			b, err := json.Marshal(FirewallPolicySource{
+				ZoneID:           "zone1",
+				MatchingTarget:   "IP",
+				PortMatchingType: "SPECIFIC",
+				Port:             tc.port,
+			})
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			assertPort(t, string(b), tc.wantPort)
+		})
+
+		t.Run("destination/"+tc.name, func(t *testing.T) {
+			b, err := json.Marshal(FirewallPolicyDestination{
+				ZoneID:           "zone2",
+				MatchingTarget:   "IP",
+				PortMatchingType: "SPECIFIC",
+				Port:             tc.port,
+			})
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			assertPort(t, string(b), tc.wantPort)
+		})
+	}
+}
+
+func assertPort(t *testing.T, got, wantPort string) {
+	t.Helper()
+	// The numeric form must never appear on the wire.
+	if strings.Contains(got, `"port":161`) {
+		t.Fatalf("port encoded as a number, firmware would reject it: %s", got)
+	}
+	if wantPort == "" {
+		if strings.Contains(got, `"port"`) {
+			t.Fatalf("expected port to be absent, got: %s", got)
+		}
+		return
+	}
+	if !strings.Contains(got, wantPort) {
+		t.Fatalf("expected %s in payload, got: %s", wantPort, got)
+	}
+}
+
+// Round-trips a string-encoded port back through decode to confirm the tolerant
+// UnmarshalJSON still reads what we now write.
+func TestFirewallPolicyPortRoundTrip(t *testing.T) {
+	src := FirewallPolicySource{Port: ptrInt64(443)}
+	b, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got FirewallPolicySource
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Port == nil || *got.Port != 443 {
+		t.Fatalf("round-trip port mismatch: got %v, want 443", got.Port)
+	}
+}


### PR DESCRIPTION
## Problem

The zone-based firewall API (UniFi Network 8.x+) rejects a `PUT`/`POST` to `firewall-policies` when the source/destination `port` is encoded as a JSON **number**. The firmware (observed on **UCG Max**, UniFi OS 5.1.x / Network 10.4.x) expects the port as a quoted **string** (e.g. `"161"`).

This surfaces in terraform-provider-unifi as an HTTP 400 on `unifi_firewall_policy` updates with a `SPECIFIC` port match (ubiquiti-community/terraform-provider-unifi#220, ubiquiti-community/terraform-provider-unifi#221).

## Fix

Add custom `MarshalJSON` for `FirewallPolicySource` and `FirewallPolicyDestination` that re-encodes `port` as a string, leaving every other field to the generated layout (anonymous-wrapper field-dominance pattern, same as `network_encode.go`). Decoding already tolerates either form via the generated `UnmarshalJSON`, so round-trips are unaffected.

## Tests

- `TestFirewallPolicyPortMarshalsAsString` — port emitted as `"161"`, never as a bare number; absent when nil.
- `TestFirewallPolicyPortRoundTrip` — string-encoded port decodes back to the int.

Both pass; full `./unifi/` suite green.

## Validation

The wire format was confirmed against a real UCG Max in the linked provider issue (manual `PUT` with `port` as a string succeeds; as a number returns 400).