### PR TITLE
fix(network): emit ipv6_client_address_assignment in corporate/guest marshalers

### DIFF
--- a/unifi/network_encode.go
+++ b/unifi/network_encode.go
@@ -113,18 +113,19 @@ func (n *Network) marshalCorporate() ([]byte, error) {
 		DHCPRelayServers []string `json:"dhcp_relay_servers"`
 
 		// IPv6
-		IPV6InterfaceType         *string `json:"ipv6_interface_type,omitempty"`
-		IPV6SettingPreference     *string `json:"ipv6_setting_preference,omitempty"`
-		IPV6RaPriority            *string `json:"ipv6_ra_priority,omitempty"`
-		IPV6Subnet                *string `json:"ipv6_subnet,omitempty"`
-		IPV6RaEnabled             bool    `json:"ipv6_ra_enabled"`
-		IPV6RaPreferredLifetime   *int64  `json:"ipv6_ra_preferred_lifetime,omitempty"`
-		IPV6RaValidLifetime       *int64  `json:"ipv6_ra_valid_lifetime,omitempty"`
-		IPV6PDInterface           *string `json:"ipv6_pd_interface,omitempty"`
-		IPV6PDPrefixid            string  `json:"ipv6_pd_prefixid"`
-		IPV6PDStart               *string `json:"ipv6_pd_start,omitempty"`
-		IPV6PDStop                *string `json:"ipv6_pd_stop,omitempty"`
-		IPV6PDAutoPrefixidEnabled bool    `json:"ipv6_pd_auto_prefixid_enabled"`
+		IPV6InterfaceType           *string `json:"ipv6_interface_type,omitempty"`
+		IPV6ClientAddressAssignment *string `json:"ipv6_client_address_assignment,omitempty"`
+		IPV6SettingPreference       *string `json:"ipv6_setting_preference,omitempty"`
+		IPV6RaPriority              *string `json:"ipv6_ra_priority,omitempty"`
+		IPV6Subnet                  *string `json:"ipv6_subnet,omitempty"`
+		IPV6RaEnabled               bool    `json:"ipv6_ra_enabled"`
+		IPV6RaPreferredLifetime     *int64  `json:"ipv6_ra_preferred_lifetime,omitempty"`
+		IPV6RaValidLifetime         *int64  `json:"ipv6_ra_valid_lifetime,omitempty"`
+		IPV6PDInterface             *string `json:"ipv6_pd_interface,omitempty"`
+		IPV6PDPrefixid              string  `json:"ipv6_pd_prefixid"`
+		IPV6PDStart                 *string `json:"ipv6_pd_start,omitempty"`
+		IPV6PDStop                  *string `json:"ipv6_pd_stop,omitempty"`
+		IPV6PDAutoPrefixidEnabled   bool    `json:"ipv6_pd_auto_prefixid_enabled"`
 
 		// DHCPv6
 		DHCPDV6Enabled    bool    `json:"dhcpdv6_enabled"`
@@ -198,18 +199,19 @@ func (n *Network) marshalCorporate() ([]byte, error) {
 		DHCPRelayServers: orEmptySlice(n.RemoteVPNSubnets),
 
 		// IPv6
-		IPV6InterfaceType:         valueOrDefault(n.IPV6InterfaceType, "none"),
-		IPV6SettingPreference:     n.IPV6SettingPreference,
-		IPV6RaPriority:            n.IPV6RaPriority,
-		IPV6Subnet:                n.IPV6Subnet,
-		IPV6RaEnabled:             n.IPV6RaEnabled,
-		IPV6RaPreferredLifetime:   n.IPV6RaPreferredLifetime,
-		IPV6RaValidLifetime:       n.IPV6RaValidLifetime,
-		IPV6PDInterface:           n.IPV6PDInterface,
-		IPV6PDPrefixid:            n.IPV6PDPrefixid,
-		IPV6PDStart:               n.IPV6PDStart,
-		IPV6PDStop:                n.IPV6PDStop,
-		IPV6PDAutoPrefixidEnabled: n.IPV6PDAutoPrefixidEnabled,
+		IPV6InterfaceType:           valueOrDefault(n.IPV6InterfaceType, "none"),
+		IPV6ClientAddressAssignment: n.IPV6ClientAddressAssignment,
+		IPV6SettingPreference:       n.IPV6SettingPreference,
+		IPV6RaPriority:              n.IPV6RaPriority,
+		IPV6Subnet:                  n.IPV6Subnet,
+		IPV6RaEnabled:               n.IPV6RaEnabled,
+		IPV6RaPreferredLifetime:     n.IPV6RaPreferredLifetime,
+		IPV6RaValidLifetime:         n.IPV6RaValidLifetime,
+		IPV6PDInterface:             n.IPV6PDInterface,
+		IPV6PDPrefixid:              n.IPV6PDPrefixid,
+		IPV6PDStart:                 n.IPV6PDStart,
+		IPV6PDStop:                  n.IPV6PDStop,
+		IPV6PDAutoPrefixidEnabled:   n.IPV6PDAutoPrefixidEnabled,
 
 		// DHCPv6
 		DHCPDV6Enabled:    n.DHCPDV6Enabled,
@@ -349,18 +351,19 @@ func (n *Network) marshalGuest() ([]byte, error) {
 		DHCPRelayServers []string `json:"dhcp_relay_servers"`
 
 		// IPv6
-		IPV6InterfaceType         *string `json:"ipv6_interface_type,omitempty"`
-		IPV6SettingPreference     *string `json:"ipv6_setting_preference,omitempty"`
-		IPV6RaPriority            *string `json:"ipv6_ra_priority,omitempty"`
-		IPV6Subnet                *string `json:"ipv6_subnet,omitempty"`
-		IPV6RaEnabled             bool    `json:"ipv6_ra_enabled"`
-		IPV6RaPreferredLifetime   *int64  `json:"ipv6_ra_preferred_lifetime,omitempty"`
-		IPV6RaValidLifetime       *int64  `json:"ipv6_ra_valid_lifetime,omitempty"`
-		IPV6PDInterface           *string `json:"ipv6_pd_interface,omitempty"`
-		IPV6PDPrefixid            string  `json:"ipv6_pd_prefixid"`
-		IPV6PDStart               *string `json:"ipv6_pd_start,omitempty"`
-		IPV6PDStop                *string `json:"ipv6_pd_stop,omitempty"`
-		IPV6PDAutoPrefixidEnabled bool    `json:"ipv6_pd_auto_prefixid_enabled"`
+		IPV6InterfaceType           *string `json:"ipv6_interface_type,omitempty"`
+		IPV6ClientAddressAssignment *string `json:"ipv6_client_address_assignment,omitempty"`
+		IPV6SettingPreference       *string `json:"ipv6_setting_preference,omitempty"`
+		IPV6RaPriority              *string `json:"ipv6_ra_priority,omitempty"`
+		IPV6Subnet                  *string `json:"ipv6_subnet,omitempty"`
+		IPV6RaEnabled               bool    `json:"ipv6_ra_enabled"`
+		IPV6RaPreferredLifetime     *int64  `json:"ipv6_ra_preferred_lifetime,omitempty"`
+		IPV6RaValidLifetime         *int64  `json:"ipv6_ra_valid_lifetime,omitempty"`
+		IPV6PDInterface             *string `json:"ipv6_pd_interface,omitempty"`
+		IPV6PDPrefixid              string  `json:"ipv6_pd_prefixid"`
+		IPV6PDStart                 *string `json:"ipv6_pd_start,omitempty"`
+		IPV6PDStop                  *string `json:"ipv6_pd_stop,omitempty"`
+		IPV6PDAutoPrefixidEnabled   bool    `json:"ipv6_pd_auto_prefixid_enabled"`
 
 		// DHCPv6
 		DHCPDV6Enabled    bool    `json:"dhcpdv6_enabled"`
@@ -434,18 +437,19 @@ func (n *Network) marshalGuest() ([]byte, error) {
 		DHCPRelayServers: orEmptySlice(n.DHCPRelayServers),
 
 		// IPv6
-		IPV6InterfaceType:         valueOrDefault(n.IPV6InterfaceType, "none"),
-		IPV6SettingPreference:     n.IPV6SettingPreference,
-		IPV6RaPriority:            n.IPV6RaPriority,
-		IPV6Subnet:                n.IPV6Subnet,
-		IPV6RaEnabled:             n.IPV6RaEnabled,
-		IPV6RaPreferredLifetime:   n.IPV6RaPreferredLifetime,
-		IPV6RaValidLifetime:       n.IPV6RaValidLifetime,
-		IPV6PDInterface:           n.IPV6PDInterface,
-		IPV6PDPrefixid:            n.IPV6PDPrefixid,
-		IPV6PDStart:               n.IPV6PDStart,
-		IPV6PDStop:                n.IPV6PDStop,
-		IPV6PDAutoPrefixidEnabled: n.IPV6PDAutoPrefixidEnabled,
+		IPV6InterfaceType:           valueOrDefault(n.IPV6InterfaceType, "none"),
+		IPV6ClientAddressAssignment: n.IPV6ClientAddressAssignment,
+		IPV6SettingPreference:       n.IPV6SettingPreference,
+		IPV6RaPriority:              n.IPV6RaPriority,
+		IPV6Subnet:                  n.IPV6Subnet,
+		IPV6RaEnabled:               n.IPV6RaEnabled,
+		IPV6RaPreferredLifetime:     n.IPV6RaPreferredLifetime,
+		IPV6RaValidLifetime:         n.IPV6RaValidLifetime,
+		IPV6PDInterface:             n.IPV6PDInterface,
+		IPV6PDPrefixid:              n.IPV6PDPrefixid,
+		IPV6PDStart:                 n.IPV6PDStart,
+		IPV6PDStop:                  n.IPV6PDStop,
+		IPV6PDAutoPrefixidEnabled:   n.IPV6PDAutoPrefixidEnabled,
 
 		// DHCPv6
 		DHCPDV6Enabled:    n.DHCPDV6Enabled,

--- a/unifi/network_encode_test.go
+++ b/unifi/network_encode_test.go
@@ -423,6 +423,50 @@ func TestMarshalNetworkGuest(t *testing.T) {
 	}
 }
 
+// TestMarshalNetworkIPv6ClientAddressAssignment guards that the corporate and
+// guest marshalers emit ipv6_client_address_assignment when set, and omit it
+// when nil. The field lives on the generated Network struct but the marshalers
+// only serialize a curated subset, so it would otherwise be silently dropped on
+// write (ubiquiti-community/terraform-provider-unifi#232).
+func TestMarshalNetworkIPv6ClientAddressAssignment(t *testing.T) {
+	for _, purpose := range []string{PurposeCorporate, PurposeGuest} {
+		t.Run(purpose, func(t *testing.T) {
+			// Set => emitted with the configured value.
+			network := &Network{
+				ID:                          "507f1f77bcf86cd799439011",
+				Purpose:                     purpose,
+				Enabled:                     true,
+				IPV6InterfaceType:           strPtr("static"),
+				IPV6ClientAddressAssignment: strPtr("slaac-dhcpv6"),
+			}
+			data, err := json.Marshal(network)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var result map[string]any
+			if err := json.Unmarshal(data, &result); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if got := result["ipv6_client_address_assignment"]; got != "slaac-dhcpv6" {
+				t.Errorf("ipv6_client_address_assignment = %v, want slaac-dhcpv6", got)
+			}
+
+			// Unset => omitted (omitempty), no perpetual diff against the API.
+			data, err = json.Marshal(&Network{ID: "x", Purpose: purpose, Enabled: true})
+			if err != nil {
+				t.Fatalf("marshal (unset): %v", err)
+			}
+			result = map[string]any{}
+			if err := json.Unmarshal(data, &result); err != nil {
+				t.Fatalf("unmarshal (unset): %v", err)
+			}
+			if _, ok := result["ipv6_client_address_assignment"]; ok {
+				t.Errorf("ipv6_client_address_assignment serialized for nil value: %s", data)
+			}
+		})
+	}
+}
+
 // Helper function to create string pointers.
 func strPtr(s string) *string {
 	return &s


### PR DESCRIPTION
## Problem
The generated `Network` struct decodes `ipv6_client_address_assignment` (the IPv6 *Client Address Assignment* mode — `slaac` / `dhcpv6` / `slaac-dhcpv6`), but `marshalCorporate` and `marshalGuest` serialize only a curated subset of fields. The value was therefore **silently dropped on every write** — readable but not settable.

## Fix
Add `ipv6_client_address_assignment` (omitempty) to both the corporate and guest marshalers so it round-trips.

## Tests
New `TestMarshalNetworkIPv6ClientAddressAssignment` (corporate + guest): asserts the field is emitted when set and omitted when nil. `go test ./...`, `go vet`, `golangci-lint`, `gofmt` clean.

Backs ubiquiti-community/terraform-provider-unifi#232 (item 1).