### PR TITLE
feat(network): marshal site-to-site IPsec VPN fields

### DIFF
--- a/unifi/network_encode.go
+++ b/unifi/network_encode.go
@@ -621,6 +621,34 @@ func (n *Network) marshalSiteVPN() ([]byte, error) {
 		Name    *string `json:"name,omitempty"`
 		Purpose string  `json:"purpose"`
 		Enabled bool    `json:"enabled"`
+
+		// VPN / IPsec
+		VPNType           *string `json:"vpn_type,omitempty"`
+		IPSecInterface    *string `json:"ipsec_interface,omitempty"`
+		IPSecPeerIP       *string `json:"ipsec_peer_ip,omitempty"`
+		IPSecLocalIP      *string `json:"ipsec_local_ip,omitempty"`
+		IPSecKeyExchange  *string `json:"ipsec_key_exchange,omitempty"`
+		IPSecPreSharedKey *string `json:"x_ipsec_pre_shared_key,omitempty"`
+		IPSecProfile      *string `json:"ipsec_profile,omitempty"`
+
+		// IKE (phase 1)
+		IPSecEncryption  *string `json:"ipsec_encryption,omitempty"`
+		IPSecHash        *string `json:"ipsec_hash,omitempty"`
+		IPSecDhGroup     *int64  `json:"ipsec_dh_group,omitempty"`
+		IPSecIkeLifetime *int64  `json:"ipsec_ike_lifetime,omitempty"`
+
+		// ESP (phase 2)
+		IPSecEspEncryption *string `json:"ipsec_esp_encryption,omitempty"`
+		IPSecEspHash       *string `json:"ipsec_esp_hash,omitempty"`
+		IPSecEspDhGroup    *int64  `json:"ipsec_esp_dh_group,omitempty"`
+		IPSecEspLifetime   *int64  `json:"ipsec_esp_lifetime,omitempty"`
+
+		IPSecPfs            bool `json:"ipsec_pfs,omitempty"`
+		IPSecDynamicRouting bool `json:"ipsec_dynamic_routing,omitempty"`
+
+		RemoteVPNSubnets  []string `json:"remote_vpn_subnets,omitempty"`
+		RemoteSiteSubnets []string `json:"remote_site_subnets,omitempty"`
+		RouteDistance     *int64   `json:"route_distance,omitempty"`
 	}{
 		ID:       n.ID,
 		SiteID:   n.SiteID,
@@ -632,6 +660,31 @@ func (n *Network) marshalSiteVPN() ([]byte, error) {
 		Name:    n.Name,
 		Purpose: n.Purpose,
 		Enabled: n.Enabled,
+
+		VPNType:           n.VPNType,
+		IPSecInterface:    n.IPSecInterface,
+		IPSecPeerIP:       n.IPSecPeerIP,
+		IPSecLocalIP:      n.IPSecLocalIP,
+		IPSecKeyExchange:  n.IPSecKeyExchange,
+		IPSecPreSharedKey: n.IPSecPreSharedKey,
+		IPSecProfile:      n.IPSecProfile,
+
+		IPSecEncryption:  n.IPSecEncryption,
+		IPSecHash:        n.IPSecHash,
+		IPSecDhGroup:     n.IPSecDhGroup,
+		IPSecIkeLifetime: n.IPSecIkeLifetime,
+
+		IPSecEspEncryption: n.IPSecEspEncryption,
+		IPSecEspHash:       n.IPSecEspHash,
+		IPSecEspDhGroup:    n.IPSecEspDhGroup,
+		IPSecEspLifetime:   n.IPSecEspLifetime,
+
+		IPSecPfs:            n.IPSecPfs,
+		IPSecDynamicRouting: n.IPSecDynamicRouting,
+
+		RemoteVPNSubnets:  n.RemoteVPNSubnets,
+		RemoteSiteSubnets: n.RemoteSiteSubnets,
+		RouteDistance:     n.RouteDistance,
 	})
 }
 

--- a/unifi/network_encode_test.go
+++ b/unifi/network_encode_test.go
@@ -467,6 +467,61 @@ func TestMarshalNetworkIPv6ClientAddressAssignment(t *testing.T) {
 	}
 }
 
+// TestMarshalNetworkSiteVPN guards that the site-to-site IPsec VPN marshaler
+// emits the VPN/IPsec fields (not just name/purpose/enabled). It was previously
+// a stub, which silently dropped the whole tunnel configuration on write
+// (ubiquiti-community/terraform-provider-unifi#78).
+func TestMarshalNetworkSiteVPN(t *testing.T) {
+	dh := int64(14)
+	network := &Network{
+		ID:                "507f1f77bcf86cd799439011",
+		Name:              strPtr("HQ-to-Branch"),
+		Purpose:           PurposeSiteVPN,
+		Enabled:           true,
+		VPNType:           strPtr("ipsec-vpn"),
+		IPSecInterface:    strPtr("wan"),
+		IPSecPeerIP:       strPtr("203.0.113.9"),
+		IPSecKeyExchange:  strPtr("ikev2"),
+		IPSecPreSharedKey: strPtr("s3cret-psk"),
+		IPSecProfile:      strPtr("customized"),
+		IPSecEncryption:   strPtr("aes256"),
+		IPSecHash:         strPtr("sha256"),
+		IPSecDhGroup:      &dh,
+		IPSecPfs:          true,
+		RemoteVPNSubnets:  []string{"192.0.2.0/24", "198.51.100.0/24"},
+	}
+
+	data, err := json.Marshal(network)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	checkJSONFields(t, data, []string{
+		"name", "purpose", "enabled", "vpn_type", "ipsec_interface",
+		"ipsec_peer_ip", "ipsec_key_exchange", "x_ipsec_pre_shared_key",
+		"ipsec_profile", "ipsec_encryption", "ipsec_hash", "ipsec_dh_group",
+		"ipsec_pfs", "remote_vpn_subnets",
+	}, []string{"ip_subnet", "dhcpd_enabled", "vlan"})
+
+	if result["purpose"] != PurposeSiteVPN {
+		t.Errorf("purpose = %v, want %q", result["purpose"], PurposeSiteVPN)
+	}
+	if result["vpn_type"] != "ipsec-vpn" {
+		t.Errorf("vpn_type = %v, want ipsec-vpn", result["vpn_type"])
+	}
+	if result["x_ipsec_pre_shared_key"] != "s3cret-psk" {
+		t.Errorf("x_ipsec_pre_shared_key = %v", result["x_ipsec_pre_shared_key"])
+	}
+	subnets, ok := result["remote_vpn_subnets"].([]any)
+	if !ok || len(subnets) != 2 {
+		t.Errorf("remote_vpn_subnets = %v, want 2 entries", result["remote_vpn_subnets"])
+	}
+}
+
 // Helper function to create string pointers.
 func strPtr(s string) *string {
 	return &s


### PR DESCRIPTION
## Problem
`marshalSiteVPN` only emitted `name`/`purpose`/`enabled` — a stub. A `purpose=site-vpn` (manual IPsec site-to-site) network therefore had its entire tunnel configuration silently dropped on write.

## Fix
Emit the VPN/IPsec fields the controller expects: `vpn_type`, `ipsec_interface`, `ipsec_peer_ip`, `ipsec_local_ip`, `ipsec_key_exchange`, `x_ipsec_pre_shared_key`, `ipsec_profile`, IKE phase-1 (`ipsec_encryption`/`ipsec_hash`/`ipsec_dh_group`/`ipsec_ike_lifetime`), ESP phase-2 (`ipsec_esp_*`), `ipsec_pfs`, `ipsec_dynamic_routing`, `remote_vpn_subnets`, `remote_site_subnets`, `route_distance`. All optional (`omitempty`) — the controller leaves advanced params null unless customized.

## Tests
New `TestMarshalNetworkSiteVPN`. Field shape verified against a live UniFi Network 10.4.57 controller (create → inspect → delete). `go test ./...` / `go vet` / `golangci-lint` / `gofmt` clean.

Backs ubiquiti-community/terraform-provider-unifi#78 (consumed by a new `unifi_site_to_site_vpn` resource).