### PR TITLE
ci(dependabot): don't fail auto-approve when auto-merge can't be enabled

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -25,7 +25,15 @@ jobs:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Enable auto-merge for Dependabot PRs
-        run: gh pr merge --auto --rebase "$PR_URL"
+        if: ${{steps.metadata.outputs.update-type != 'version-update:semver-major'}}
+        # `gh pr merge --auto` can only enable auto-merge when the branch is
+        # protected with required checks; on an unprotected `main` it errors with
+        # "Pull request is in unstable status". Tolerate that so the workflow
+        # stays green — the PR is already approved and can be merged manually
+        # (and auto-merge will start working once branch protection is added).
+        run: |
+          gh pr merge --auto --rebase "$PR_URL" \
+            || echo "auto-merge not enabled (main is not a protected branch); PR approved, merge manually."
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## Problem
The `Dependabot auto-approve` workflow fails on **every** dependabot PR at the *Enable auto-merge* step:
```
GraphQL: Pull request Pull request is in unstable status (enablePullRequestAutoMerge)
```
`gh pr merge --auto` can only enable auto-merge when the branch is protected with required checks. `main` here is **not** a protected branch, so the mutation is rejected and the workflow goes red — even though the dependency bumps themselves pass Test/Lint/generate/yamllint.

## Fix
- Tolerate the auto-merge failure (`|| echo …`) so the workflow stays green; the PR is still auto-approved and can be merged manually. Auto-merge will start working automatically if branch protection with required checks is later added to `main`.
- Gate the auto-merge step on non-major updates, matching the approve step.

No functional change to what actually merges today (auto-merge was already not happening — it was just failing loudly).