### PR TITLE
feat(firewall-policy): add web_domains (FQDN) matching to source/destination

### DIFF
--- a/cmd/fields/custom/FirewallPolicy.json
+++ b/cmd/fields/custom/FirewallPolicy.json
@@ -14,11 +14,14 @@
     "network_ids": [
       ""
     ],
+    "web_domains": [
+      ""
+    ],
     "match_mac": "true|false",
     "match_opposite_ips": "true|false",
     "match_opposite_ports": "true|false",
     "match_opposite_networks": "true|false",
-    "matching_target": "ANY|DEVICE|IP|NETWORK|CLIENT|MAC",
+    "matching_target": "ANY|DEVICE|IP|NETWORK|CLIENT|MAC|WEB",
     "matching_target_type": "ANY|SPECIFIC|LIST|OBJECT",
     "port": "[1-9][0-9]{0,4}",
     "port_group_id": "",
@@ -56,11 +59,14 @@
     "network_ids": [
       ""
     ],
+    "web_domains": [
+      ""
+    ],
     "match_mac": "true|false",
     "match_opposite_ips": "true|false",
     "match_opposite_ports": "true|false",
     "match_opposite_networks": "true|false",
-    "matching_target": "ANY|DEVICE|IP|NETWORK|CLIENT|MAC",
+    "matching_target": "ANY|DEVICE|IP|NETWORK|CLIENT|MAC|WEB",
     "matching_target_type": "ANY|SPECIFIC|LIST|OBJECT",
     "port": "[1-9][0-9]{0,4}",
     "port_group_id": "",

--- a/unifi/firewall_policy.generated.go
+++ b/unifi/firewall_policy.generated.go
@@ -87,12 +87,13 @@ type FirewallPolicyDestination struct {
 	MatchOppositeIPs      bool     `json:"match_opposite_ips"`
 	MatchOppositeNetworks bool     `json:"match_opposite_networks"`
 	MatchOppositePorts    bool     `json:"match_opposite_ports"`
-	MatchingTarget        string   `json:"matching_target,omitempty"`      // ANY|DEVICE|IP|NETWORK|CLIENT|MAC
+	MatchingTarget        string   `json:"matching_target,omitempty"`      // ANY|DEVICE|IP|NETWORK|CLIENT|MAC|WEB
 	MatchingTargetType    string   `json:"matching_target_type,omitempty"` // ANY|SPECIFIC|LIST|OBJECT
 	NetworkIDs            []string `json:"network_ids,omitempty"`
 	Port                  *int64   `json:"port,omitempty"` // [1-9][0-9]{0,4}
 	PortGroupID           string   `json:"port_group_id,omitempty"`
 	PortMatchingType      string   `json:"port_matching_type,omitempty"` // ANY|SPECIFIC|LIST|OBJECT
+	WebDomains            []string `json:"web_domains,omitempty"`
 	ZoneID                string   `json:"zone_id,omitempty"`
 }
 
@@ -154,12 +155,13 @@ type FirewallPolicySource struct {
 	MatchOppositeIPs      bool     `json:"match_opposite_ips"`
 	MatchOppositeNetworks bool     `json:"match_opposite_networks"`
 	MatchOppositePorts    bool     `json:"match_opposite_ports"`
-	MatchingTarget        string   `json:"matching_target,omitempty"`      // ANY|DEVICE|IP|NETWORK|CLIENT|MAC
+	MatchingTarget        string   `json:"matching_target,omitempty"`      // ANY|DEVICE|IP|NETWORK|CLIENT|MAC|WEB
 	MatchingTargetType    string   `json:"matching_target_type,omitempty"` // ANY|SPECIFIC|LIST|OBJECT
 	NetworkIDs            []string `json:"network_ids,omitempty"`
 	Port                  *int64   `json:"port,omitempty"` // [1-9][0-9]{0,4}
 	PortGroupID           string   `json:"port_group_id,omitempty"`
 	PortMatchingType      string   `json:"port_matching_type,omitempty"` // ANY|SPECIFIC|LIST|OBJECT
+	WebDomains            []string `json:"web_domains,omitempty"`
 	ZoneID                string   `json:"zone_id,omitempty"`
 }
 


### PR DESCRIPTION
## Summary
Adds the `web_domains` field to `FirewallPolicySource` and `FirewallPolicyDestination`, plus the `WEB` value for `matching_target`, so a firewall policy can match traffic by domain/FQDN.

This mirrors what the zone-policy schema exposes elsewhere (`web_domains []string` + `matching_target = WEB`) and unblocks ubiquiti-community/terraform-provider-unifi#242 ("Missing domains support in firewall settings").

## Changes
- `cmd/fields/custom/FirewallPolicy.json`: add `web_domains` to both `source` and `destination`, and add `WEB` to the `matching_target` enum.
- `unifi/firewall_policy.generated.go`: add the `WebDomains []string `json:"web_domains,omitempty"`` field to both structs (alphabetical position, between `PortMatchingType` and `ZoneID`) and update the `matching_target` enum comment.

## Notes
- The generated struct was edited by hand (consistently with the custom JSON) because the field generator downloads the controller JAR from `fw-update.ubnt.com`, which returns `Forbidden` in this environment — same approach as #17.
- `WebDomains` is a plain `[]string`; it is marshaled automatically through the existing `Alias`-based `MarshalJSON`, so no encode/decode changes are needed.
- `go build ./...` and `go test ./unifi/` pass.