### PR TITLE
fix(security): redact secrets from request payload in error messages

### DIFF
--- a/unifi/redact_test.go
+++ b/unifi/redact_test.go
@@ -1,0 +1,58 @@
+package unifi
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestRedactSensitivePayload guards that secrets embedded in a request body are
+// not leaked when the body is included in an error message
+// (ubiquiti-community/terraform-provider-unifi#256).
+func TestRedactSensitivePayload(t *testing.T) {
+	const (
+		wgKey     = "fake-wireguard-key-value"
+		pass      = "fake-passphrase-value"
+		ipsecPSK  = "fake-ipsec-psk-value"
+		radiusSec = "fake-radius-secret-value"
+		pw        = "fake-password-value"
+	)
+	body := []byte(`{
+		"name": "wgadmin",
+		"purpose": "vpn-server",
+		"x_wireguard_private_key": "` + wgKey + `",
+		"x_passphrase": "` + pass + `",
+		"x_ipsec_pre_shared_key": "` + ipsecPSK + `",
+		"vlan": 50,
+		"nested": {"radius_secret": "` + radiusSec + `", "ok": "keep"},
+		"list": [{"password": "` + pw + `"}]
+	}`)
+
+	out := redactSensitivePayload(body)
+
+	for _, leak := range []string{wgKey, pass, ipsecPSK, radiusSec, pw} {
+		if strings.Contains(out, leak) {
+			t.Errorf("redacted payload still leaks %q: %s", leak, out)
+		}
+	}
+
+	// Non-sensitive fields must survive.
+	var m map[string]any
+	if err := json.Unmarshal([]byte(out), &m); err != nil {
+		t.Fatalf("redacted payload is not valid JSON: %v\n%s", err, out)
+	}
+	if m["name"] != "wgadmin" {
+		t.Errorf("name was lost: %v", m["name"])
+	}
+	if m["x_wireguard_private_key"] != "REDACTED" {
+		t.Errorf("private key not redacted: %v", m["x_wireguard_private_key"])
+	}
+	if nested, ok := m["nested"].(map[string]any); !ok || nested["ok"] != "keep" {
+		t.Errorf("nested non-sensitive value lost: %v", m["nested"])
+	}
+
+	// Non-JSON body is omitted, not echoed.
+	if got := redactSensitivePayload([]byte("not json")); strings.Contains(got, "not json") {
+		t.Errorf("non-JSON body echoed: %q", got)
+	}
+}

--- a/unifi/unifi.go
+++ b/unifi/unifi.go
@@ -704,7 +704,7 @@ func (c *ApiClient) doRequest(
 			strings.TrimSpace(resp.Status),
 			method,
 			url.String(),
-			string(reqBytes),
+			redactSensitivePayload(reqBytes),
 		)
 	}
 
@@ -761,6 +761,67 @@ func parseRetryAfter(resp *http.Response) time.Duration {
 		}
 	}
 	return 0
+}
+
+// sensitivePayloadKeys are substrings of JSON field names whose values carry
+// secrets (WireGuard/IPsec keys, passphrases, RADIUS secrets, …) and must be
+// redacted from error messages and logs.
+var sensitivePayloadKeys = []string{
+	"private_key",
+	"passphrase",
+	"pre_shared_key",
+	"password",
+	"secret",
+	"psk",
+}
+
+// redactSensitivePayload returns the JSON request body with the values of any
+// sensitive fields replaced by "REDACTED", so secrets (e.g.
+// x_wireguard_private_key, x_passphrase, x_ipsec_pre_shared_key) are never
+// leaked into error messages. If the body is not valid JSON it is omitted.
+func redactSensitivePayload(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
+	var v any
+	if err := json.Unmarshal(b, &v); err != nil {
+		return "[non-JSON payload omitted]"
+	}
+	redactSensitiveValue(v)
+	out, err := json.Marshal(v)
+	if err != nil {
+		return "[payload omitted]"
+	}
+	return string(out)
+}
+
+func redactSensitiveValue(v any) {
+	switch t := v.(type) {
+	case map[string]any:
+		for k, val := range t {
+			if isSensitiveKey(k) {
+				if _, ok := val.(string); ok {
+					t[k] = "REDACTED"
+					continue
+				}
+			}
+			redactSensitiveValue(val)
+		}
+	case []any:
+		for _, item := range t {
+			redactSensitiveValue(item)
+		}
+	}
+}
+
+func isSensitiveKey(k string) bool {
+	lk := strings.ToLower(k)
+	for _, s := range sensitivePayloadKeys {
+		if strings.Contains(lk, s) {
+			return true
+		}
+	}
+	return false
 }
 
 func Ptr[T any](in T) *T {


### PR DESCRIPTION
When a request fails, `doRequest` embedded the **raw JSON request body** in the returned error (`...\npayload: %s`). For WireGuard/IPsec/WLAN resources that body contains secrets in cleartext — `x_wireguard_private_key`, `x_passphrase`, `x_ipsec_pre_shared_key` — leaking them into terminal scrollback and CI logs.

Redact the values of sensitive fields (key names containing `private_key`/`passphrase`/`pre_shared_key`/`password`/`secret`/`psk`) to `REDACTED` before including the payload, recursively through nested objects/arrays, and omit the payload entirely when it is not valid JSON.

New `TestRedactSensitivePayload`. `go test ./...` / `go vet` / `golangci-lint` clean.

Backs ubiquiti-community/terraform-provider-unifi#256.