### PR TITLE
feat(power-supervisor): add Device Supervisor v2 API client

### DIFF
--- a/unifi/power_supervisor.go
+++ b/unifi/power_supervisor.go
@@ -1,0 +1,170 @@
+package unifi
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// This is a v2 API object, manually coded.
+//
+// Power supervisors back the "Device Supervisor" feature (UniFi Network 10.2+):
+// heartbeat monitoring of a device (keyed by client_mac) plus automatic
+// power-cycling of its upstream PoE source after a silence threshold. The
+// controller exposes them as a dedicated per-device collection on the v2 API
+// (one entry per supervised device), not as a field on the device object.
+
+type PowerSupervisor struct {
+	ID     string `json:"id,omitempty"`
+	SiteID string `json:"site_id,omitempty"`
+
+	ClientMAC string                  `json:"client_mac"`
+	Enabled   bool                    `json:"enabled"`
+	Settings  PowerSupervisorSettings `json:"settings"`
+	// PowerSources may be sent empty on create — the controller resolves the
+	// upstream PoE port automatically and populates them on read.
+	PowerSources []PowerSupervisorSource `json:"power_sources"`
+
+	// Computed/read-only.
+	ConsecutiveFailures int `json:"consecutive_failures,omitempty"`
+}
+
+// PowerSupervisorSettings are the heartbeat/power-cycle timings, all in seconds.
+type PowerSupervisorSettings struct {
+	HeartbeatInterval int `json:"heartbeat_interval"`
+	SilenceThreshold  int `json:"silence_threshold"`
+	PowerOffDuration  int `json:"power_off_duration"`
+}
+
+// PowerSupervisorSource references the upstream power source used to recover the
+// supervised device. The controller resolves and fills these on read.
+type PowerSupervisorSource struct {
+	ClientPsuIndex   int    `json:"client_psu_index,omitempty"`
+	PowerSourceIndex int    `json:"power_source_index,omitempty"`
+	PowerSourceMAC   string `json:"power_source_mac,omitempty"`
+	PowerSourceType  string `json:"power_source_type,omitempty"`
+}
+
+func (c *ApiClient) powerSupervisorsPath(site string) string {
+	return fmt.Sprintf("v2/api/site/%s/power-supervisors", site)
+}
+
+func (c *ApiClient) ListPowerSupervisors(
+	ctx context.Context,
+	site string,
+) ([]PowerSupervisor, error) {
+	var respBody []PowerSupervisor
+
+	err := c.do(ctx, http.MethodGet, c.powerSupervisorsPath(site), nil, &respBody)
+	if err != nil {
+		return nil, err
+	}
+
+	return respBody, nil
+}
+
+// GetPowerSupervisor fetches a single supervisor by ID by listing and filtering.
+func (c *ApiClient) GetPowerSupervisor(
+	ctx context.Context,
+	site, id string,
+) (*PowerSupervisor, error) {
+	supervisors, err := c.ListPowerSupervisors(ctx, site)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range supervisors {
+		if supervisors[i].ID == id {
+			return &supervisors[i], nil
+		}
+	}
+
+	return nil, &NotFoundError{Type: "power_supervisor", Attr: "id", Value: id}
+}
+
+// GetPowerSupervisorByMAC fetches the supervisor for a supervised device by its
+// client MAC (the collection is keyed per device), useful for import.
+func (c *ApiClient) GetPowerSupervisorByMAC(
+	ctx context.Context,
+	site, mac string,
+) (*PowerSupervisor, error) {
+	supervisors, err := c.ListPowerSupervisors(ctx, site)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range supervisors {
+		if supervisors[i].ClientMAC == mac {
+			return &supervisors[i], nil
+		}
+	}
+
+	return nil, &NotFoundError{Type: "power_supervisor", Attr: "client_mac", Value: mac}
+}
+
+func (c *ApiClient) CreatePowerSupervisor(
+	ctx context.Context,
+	site string,
+	d *PowerSupervisor,
+) (*PowerSupervisor, error) {
+	var respBody PowerSupervisor
+	d.ID = ""
+	if d.PowerSources == nil {
+		d.PowerSources = []PowerSupervisorSource{}
+	}
+
+	err := c.do(ctx, http.MethodPost, c.powerSupervisorsPath(site), d, &respBody)
+	if err != nil {
+		return nil, err
+	}
+
+	// The create response may not echo the persisted object (and thus its id).
+	// Fall back to listing and matching on the device MAC so callers always get
+	// the server-assigned id back.
+	if respBody.ID == "" {
+		return c.GetPowerSupervisorByMAC(ctx, site, d.ClientMAC)
+	}
+
+	return &respBody, nil
+}
+
+func (c *ApiClient) UpdatePowerSupervisor(
+	ctx context.Context,
+	site string,
+	d *PowerSupervisor,
+) (*PowerSupervisor, error) {
+	var respBody PowerSupervisor
+	if d.PowerSources == nil {
+		d.PowerSources = []PowerSupervisorSource{}
+	}
+
+	err := c.do(
+		ctx,
+		http.MethodPut,
+		fmt.Sprintf("%s/%s", c.powerSupervisorsPath(site), d.ID),
+		d,
+		&respBody,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if respBody.ID == "" {
+		return c.GetPowerSupervisor(ctx, site, d.ID)
+	}
+
+	return &respBody, nil
+}
+
+func (c *ApiClient) DeletePowerSupervisor(
+	ctx context.Context,
+	site, id string,
+) error {
+	return c.do(
+		ctx,
+		http.MethodDelete,
+		fmt.Sprintf("%s/%s", c.powerSupervisorsPath(site), id),
+		struct{}{},
+		nil,
+	)
+}

--- a/unifi/power_supervisor_test.go
+++ b/unifi/power_supervisor_test.go
@@ -1,0 +1,63 @@
+package unifi_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/ubiquiti-community/go-unifi/unifi"
+)
+
+func TestPowerSupervisorMarshalJSON(t *testing.T) {
+	// Create body shape: power_sources may be sent empty.
+	ps := unifi.PowerSupervisor{
+		ClientMAC: "00:11:22:33:44:55",
+		Enabled:   true,
+		Settings: unifi.PowerSupervisorSettings{
+			HeartbeatInterval: 60,
+			SilenceThreshold:  900,
+			PowerOffDuration:  120,
+		},
+		PowerSources: []unifi.PowerSupervisorSource{},
+	}
+
+	actual, err := json.Marshal(&ps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.JSONEq(t,
+		`{"client_mac":"00:11:22:33:44:55","enabled":true,`+
+			`"settings":{"heartbeat_interval":60,"silence_threshold":900,"power_off_duration":120},`+
+			`"power_sources":[]}`,
+		string(actual))
+}
+
+func TestPowerSupervisorUnmarshalJSON(t *testing.T) {
+	// Resting shape returned by GET, with the controller-resolved power source.
+	raw := `{
+		"id": "000000000000000000000001",
+		"site_id": "000000000000000000000002",
+		"client_mac": "00:11:22:33:44:55",
+		"enabled": true,
+		"consecutive_failures": 0,
+		"settings": {"heartbeat_interval": 60, "silence_threshold": 900, "power_off_duration": 120},
+		"power_sources": [
+			{"client_psu_index": 1, "power_source_index": 4, "power_source_mac": "66:77:88:99:aa:bb", "power_source_type": "poe_port"}
+		]
+	}`
+
+	var ps unifi.PowerSupervisor
+	if err := json.Unmarshal([]byte(raw), &ps); err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "000000000000000000000001", ps.ID)
+	assert.Equal(t, "00:11:22:33:44:55", ps.ClientMAC)
+	assert.True(t, ps.Enabled)
+	assert.Equal(t, 900, ps.Settings.SilenceThreshold)
+	if assert.Len(t, ps.PowerSources, 1) {
+		assert.Equal(t, "66:77:88:99:aa:bb", ps.PowerSources[0].PowerSourceMAC)
+		assert.Equal(t, 4, ps.PowerSources[0].PowerSourceIndex)
+		assert.Equal(t, "poe_port", ps.PowerSources[0].PowerSourceType)
+	}
+}


### PR DESCRIPTION
## Context
Device Supervisor (UniFi Network 10.2+) — heartbeat monitoring of a device plus automatic PoE power-cycling of its upstream source after a silence threshold — is not in the SDK. It is exposed on the **v2 API** as a dedicated per-device collection at `/v2/api/site/<site>/power-supervisors`, keyed by `client_mac` (one entry per supervised device), not as a field on the device object. Needed by terraform-provider-unifi#244.

## Changes
Add a hand-written v2 client (`power_supervisor.go`), mirroring the existing `wireguard_peer` / `firewall_zone` v2 clients:
- `PowerSupervisor` + `PowerSupervisorSettings` (heartbeat/silence/power-off, all seconds) + `PowerSupervisorSource` (the resolved upstream PoE source) structs.
- `List` / `Get` (by id) / `GetByMAC` (for import) / `Create` / `Update` / `Delete`.
- `Create` sends `power_sources` empty — the controller resolves the upstream PoE port automatically — and falls back to a MAC lookup if the POST response does not echo the server-assigned `id`.

## Tests
- `TestPowerSupervisorMarshalJSON` / `...UnmarshalJSON` cover the create body and the resting GET shape (with a controller-resolved `power_sources` entry). `go build` / `go vet` / `gofmt` clean.

Payload shapes captured from a live UDM-SE on UniFi Network 10.4.57 (terraform-provider-unifi#244).