### PR TITLE
fix(errors): surface v2 API error message instead of a bare HTTP status

### DIFF
--- a/unifi/error_v2_test.go
+++ b/unifi/error_v2_test.go
@@ -1,0 +1,47 @@
+package unifi
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestV2APIErrorMessageSurfaced verifies that an error from the v2 API — which
+// uses a {"code","message","errorCode"} body, unlike the v1 {"meta":{"rc","msg"}}
+// shape — surfaces the controller's actual message instead of a bare HTTP 400.
+// Regression guard for the Device Supervisor PoE validation error
+// (api.err.PurePoeRequiresUplinkException) showing up as just "(400 Bad Request)".
+func TestV2APIErrorMessageSurfaced(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if handleNewStyleSetup(w, r) {
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{
+			"code": "api.err.PurePoeRequiresUplinkException",
+			"message": "Invalid pure PoE supervisor configuration: PORT_NOT_POE_CAPABLE",
+			"errorCode": 400
+		}`))
+	}))
+	defer srv.Close()
+
+	c, err := New(context.Background(), &Config{BaseURL: srv.URL, APIKey: "test-key"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	var out []PowerSupervisor
+	err = c.do(context.Background(), http.MethodGet, "v2/api/site/default/power-supervisors", nil, &out)
+	if err == nil {
+		t.Fatal("expected an error from the v2 400 response, got nil")
+	}
+	if !strings.Contains(err.Error(), "PORT_NOT_POE_CAPABLE") {
+		t.Errorf("v2 error message not surfaced; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "api.err.PurePoeRequiresUplinkException") {
+		t.Errorf("v2 error code not surfaced; got: %v", err)
+	}
+}

--- a/unifi/unifi.go
+++ b/unifi/unifi.go
@@ -681,13 +681,14 @@ func (c *ApiClient) doRequest(
 		if resp.StatusCode == http.StatusUnauthorized {
 			return &LoginRequiredError{APIKey: c.apiKey != ""}
 		}
+		errBytes, _ := io.ReadAll(resp.Body)
 		errBody := struct {
 			Meta meta `json:"meta"`
 			Data []struct {
 				Meta meta `json:"meta"`
 			} `json:"data"`
 		}{}
-		if err = json.NewDecoder(resp.Body).Decode(&errBody); err != nil {
+		if err = json.Unmarshal(errBytes, &errBody); err != nil {
 			return err
 		}
 		var apiErr error
@@ -697,6 +698,26 @@ func (c *ApiClient) doRequest(
 		}
 		if apiErr == nil {
 			apiErr = errBody.Meta.error()
+		}
+		// The v2 API reports errors with a different shape
+		// ({"code","message","errorCode"}) that the v1 meta decoder above leaves
+		// empty. Fall back to it so callers get the controller's actual message
+		// (e.g. api.err.PurePoeRequiresUplinkException) instead of a bare HTTP 400.
+		if ae, ok := apiErr.(*APIError); !ok || ae == nil || ae.Message == "" {
+			v2 := struct {
+				Code    string `json:"code"`
+				Message string `json:"message"`
+			}{}
+			if json.Unmarshal(errBytes, &v2) == nil && (v2.Message != "" || v2.Code != "") {
+				msg := v2.Message
+				switch {
+				case msg == "":
+					msg = v2.Code
+				case v2.Code != "":
+					msg = v2.Code + ": " + msg
+				}
+				apiErr = &APIError{RC: v2.Code, Message: msg}
+			}
 		}
 		return fmt.Errorf(
 			"%w (%s) for %s %s\npayload: %s",


### PR DESCRIPTION
## Context
The error decoder in `do()` only parsed the **v1** API error shape (`{"meta":{"rc","msg"}}` / `{"data":[{"meta":...}]}`). The **v2** API reports errors with a different shape — `{"code","message","errorCode"}` — which the v1 decoder leaves empty. So every v2 resource failure (firewall policy/zone, wireguard peer, power supervisor) surfaced as just `(400 Bad Request)` with no reason.

Found while live-testing the Device Supervisor resource (terraform-provider-unifi#244): supervising a non-PoE device returns a precise controller message (`api.err.PurePoeRequiresUplinkException` / `PORT_NOT_POE_CAPABLE`) that was being swallowed.

## Changes
Read the error body once and fall back to the v2 shape when the v1 `meta` carries no message, folding `code` into the message so callers see both. v1 behavior is unchanged.

## Tests
- `TestV2APIErrorMessageSurfaced` (httptest) asserts a v2 400 body surfaces both the message and the `api.err.*` code. Full suite + `go vet` + `gofmt` clean.