### PR TITLE
feat(client): expose last_ip as a read-only field

### DIFF
--- a/cmd/fields/main.go
+++ b/cmd/fields/main.go
@@ -229,6 +229,9 @@ func NewResource(structName string, resourcePath string) *ResourceInfo {
 		baseType.Fields["IP"] = NewFieldInfo("IP", "ip", fields.String, "", true, false, false, "")
 	case resource.StructName == "Client":
 		baseType.Fields[" DisplayName"] = NewFieldInfo("DisplayName", "display_name", fields.String, "non-generated field", true, false, false, "")
+		// The controller reports the client's most recent IP on /rest/user but
+		// ace.jar has no schema for it; surface it as a read-only field.
+		baseType.Fields["LastIP"] = NewFieldInfo("LastIP", "last_ip", fields.String, "non-generated field", true, false, false, "")
 	case resource.StructName == "WLAN":
 		// this field removed in v6, retaining for backwards compatibility
 		baseType.Fields["WLANGroupID"] = NewFieldInfo("WLANGroupID", "wlangroup_id", fields.String, "", true, false, false, "")

--- a/unifi/client.generated.go
+++ b/unifi/client.generated.go
@@ -40,6 +40,7 @@ type Client struct {
 	FixedApMAC                    string   `json:"fixed_ap_mac,omitempty"` // ^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$
 	FixedIP                       string   `json:"fixed_ip,omitempty"`
 	Hostname                      string   `json:"hostname,omitempty"`
+	LastIP                        string   `json:"last_ip,omitempty"`
 	LastSeen                      *int64   `json:"last_seen,omitempty"`
 	LocalDNSRecord                string   `json:"local_dns_record,omitempty"`
 	LocalDNSRecordEnabled         bool     `json:"local_dns_record_enabled"`


### PR DESCRIPTION
The controller reports a client's most recent IP as `last_ip` on `/rest/user` (verified on UniFi Network 10.x), but ace.jar has no schema for it so the codegen dropped it. Add it as a plain read-only string on the `Client` struct, plus the codegen `Client` case so a regen keeps it. Enables terraform-provider-unifi#287 (expose `last_ip` on `unifi_client`).