### PR TITLE
fix(firewall-zone): omit server-computed default_zone (make it *bool)

### DIFF
--- a/cmd/fields/main.go
+++ b/cmd/fields/main.go
@@ -176,6 +176,17 @@ func NewResource(structName string, resourcePath string) *ResourceInfo {
 		resource.ResourcePath = "static-dns"
 	case resource.StructName == "FirewallZone":
 		resource.ResourcePath = "firewall/zone"
+		resource.FieldProcessor = func(name string, f *FieldInfo) error {
+			// default_zone is server-computed/read-only. Sending it in the
+			// create body makes UniFi Network 10.4.x reject the POST with
+			// "Unrecognized field default_zone" (terraform-provider-unifi#310).
+			// Make it a *bool with omitempty so an unset value is omitted.
+			if name == "DefaultZone" {
+				f.OmitEmpty = true
+				f.IsPointer = true
+			}
+			return nil
+		}
 	case resource.StructName == "OSPFRouter":
 		resource.ResourcePath = "ospf/router"
 	case resource.StructName == "FirewallPolicy":

--- a/unifi/firewall_zone.generated.go
+++ b/unifi/firewall_zone.generated.go
@@ -33,7 +33,7 @@ type FirewallZone struct {
 	NoDelete bool   `json:"attr_no_delete,omitempty"`
 	NoEdit   bool   `json:"attr_no_edit,omitempty"`
 
-	DefaultZone bool     `json:"default_zone"`
+	DefaultZone *bool    `json:"default_zone,omitempty"`
 	Name        string   `json:"name,omitempty"`
 	NetworkIDs  []string `json:"network_ids,omitempty"`
 	ZoneKey     string   `json:"zone_key,omitempty"`


### PR DESCRIPTION
`FirewallZone.DefaultZone` was a plain `bool` without `omitempty`, so create POSTs always sent `"default_zone":false`. UniFi Network 10.4.x rejects the unknown field on the v2 `firewall/zone` create endpoint with `400 "Unrecognized field default_zone"` (a name-only body is accepted). `default_zone` is server-computed/read-only.

Make it `*bool` with `omitempty` (via a `FirewallZone` `FieldProcessor` so a regen reproduces it) → an unset value is omitted from the request while still decoding on read.

Enables terraform-provider-unifi#310 (the provider will leave it nil on write and read it back as a computed attribute).