### PR TITLE
fix(firewall-zone): always send network_ids on create (omitempty → HTTP 500)

### DIFF
--- a/cmd/fields/main.go
+++ b/cmd/fields/main.go
@@ -185,6 +185,15 @@ func NewResource(structName string, resourcePath string) *ResourceInfo {
 				f.OmitEmpty = true
 				f.IsPointer = true
 			}
+			// network_ids must always be present in the create body. The v2
+			// firewall/zone POST returns HTTP 500 when the field is omitted
+			// entirely, and the default codegen marks slices omitempty — which
+			// drops an empty []string and breaks creating a zone that has no
+			// networks assigned yet. Keep it always serialized so an empty list
+			// is sent as "network_ids":[] (which the controller accepts).
+			if name == "NetworkIDs" {
+				f.OmitEmpty = false
+			}
 			return nil
 		}
 	case resource.StructName == "OSPFRouter":

--- a/unifi/firewall_zone.generated.go
+++ b/unifi/firewall_zone.generated.go
@@ -35,7 +35,7 @@ type FirewallZone struct {
 
 	DefaultZone *bool    `json:"default_zone,omitempty"`
 	Name        string   `json:"name,omitempty"`
-	NetworkIDs  []string `json:"network_ids,omitempty"`
+	NetworkIDs  []string `json:"network_ids"`
 	ZoneKey     string   `json:"zone_key,omitempty"`
 }
 

--- a/unifi/firewall_zone_test.go
+++ b/unifi/firewall_zone_test.go
@@ -1,0 +1,24 @@
+package unifi
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Regression for terraform-provider-unifi zone CREATE 500: an empty NetworkIDs
+// must serialize as "network_ids":[] (the controller 500s when the field is
+// omitted). Before dropping omitempty this body had no network_ids key.
+func TestFirewallZoneMarshalIncludesEmptyNetworkIDs(t *testing.T) {
+	b, err := json.Marshal(&FirewallZone{Name: "tf-canary", NetworkIDs: []string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(b)
+	if !strings.Contains(got, `"network_ids":[]`) {
+		t.Fatalf("expected network_ids to be present as []; got %s", got)
+	}
+	if strings.Contains(got, "default_zone") {
+		t.Fatalf("default_zone should be omitted on write; got %s", got)
+	}
+}


### PR DESCRIPTION
## Problem

Creating a firewall zone via the v2 `firewall/zone` POST returns **HTTP 500** when the request body omits `network_ids` entirely.

The generated `FirewallZone` struct marked the field `omitempty`:

```go
NetworkIDs []string `json:"network_ids,omitempty"`
```

So creating a zone that has **no networks assigned yet** (`NetworkIDs: []string{}`) drops the key from the body, and the controller 500s. This blocks `unifi_firewall_zone` creation in terraform-provider-unifi and forces the long-standing "create the zone via the v2 API, then `terraform import`" workaround. (This is the failure that remained after #45 fixed the earlier `default_zone` **400**.)

I confirmed the controller's behavior directly:

| Body | Result |
|------|--------|
| `{"name":"x"}` (no `network_ids`) | **500 Internal Server Error** |
| `{"name":"x","network_ids":[]}` | **201 Created** |

## Fix

Drop `omitempty` for `network_ids` via the existing `FirewallZone` `FieldProcessor` (same mechanism as the `default_zone` fix in #45), so an empty list serializes as `"network_ids":[]` — which the controller accepts.

- `cmd/fields/main.go` — `FieldProcessor` sets `OmitEmpty = false` for `NetworkIDs`.
- `unifi/firewall_zone.generated.go` — regenerated tag: `json:"network_ids"`.
- `unifi/firewall_zone_test.go` — marshal regression test.

## Testing

- `go test ./unifi/ -run FirewallZone` passes (new marshal test asserts `"network_ids":[]` is present and `default_zone` stays omitted on write).
- **End-to-end against a live UniFi Network controller** using a client built from this branch: `CreateFirewallZone` with `NetworkIDs: []string{}` now returns **201** and round-trips, where it previously 500'd. Created and deleted a throwaway zone cleanly.

Refs: terraform-provider-unifi zone-create 500 (follow-up to #45 / terraform-provider-unifi#310).