### PR TITLE
feat(firewall-policy): add ip_group_id to source/destination

### DIFF
--- a/cmd/fields/custom/FirewallPolicy.json
+++ b/cmd/fields/custom/FirewallPolicy.json
@@ -25,6 +25,7 @@
     "matching_target_type": "ANY|SPECIFIC|LIST|OBJECT",
     "port": "",
     "port_group_id": "",
+    "ip_group_id": "",
     "port_matching_type": "ANY|SPECIFIC|LIST|OBJECT",
     "zone_id": ""
   },
@@ -70,6 +71,7 @@
     "matching_target_type": "ANY|SPECIFIC|LIST|OBJECT",
     "port": "",
     "port_group_id": "",
+    "ip_group_id": "",
     "port_matching_type": "ANY|SPECIFIC|LIST|OBJECT",
     "zone_id": ""
   }

--- a/unifi/firewall_policy.generated.go
+++ b/unifi/firewall_policy.generated.go
@@ -82,6 +82,7 @@ func (dst *FirewallPolicy) UnmarshalJSON(b []byte) error {
 
 type FirewallPolicyDestination struct {
 	ClientMACs            []string `json:"client_macs,omitempty"`
+	IPGroupID             string   `json:"ip_group_id,omitempty"`
 	IPs                   []string `json:"ips,omitempty"`
 	MatchMAC              bool     `json:"match_mac"`
 	MatchOppositeIPs      bool     `json:"match_opposite_ips"`
@@ -143,6 +144,7 @@ func (dst *FirewallPolicySchedule) UnmarshalJSON(b []byte) error {
 
 type FirewallPolicySource struct {
 	ClientMACs            []string `json:"client_macs,omitempty"`
+	IPGroupID             string   `json:"ip_group_id,omitempty"`
 	IPs                   []string `json:"ips,omitempty"`
 	MatchMAC              bool     `json:"match_mac"`
 	MatchOppositeIPs      bool     `json:"match_opposite_ips"`


### PR DESCRIPTION
## Summary

Adds the `ip_group_id` field to `FirewallPolicySource` and `FirewallPolicyDestination`.

UniFi zone-based firewall policies can match an **IP group** (a `unifi_firewall_group` of type address-group) on the source or destination. The controller returns it alongside the existing `port_group_id`:

```json
"destination": {
  "ip_group_id": "68945578bfcb5d2e51dd0f10",
  "port_group_id": "6894559bbfcb5d2e51dd0f16",
  "matching_target": "IP",
  "matching_target_type": "OBJECT",
  ...
}
```

The field was missing from the SDK structs, so the provider can't surface it (downstream ubiquiti-community/terraform-provider-unifi#316).

## Changes

- `cmd/fields/custom/FirewallPolicy.json`: add `ip_group_id` to `source` and `destination`.
- `unifi/firewall_policy.generated.go`: add `IPGroupID string \`json:"ip_group_id,omitempty\"\`` to both structs (plain string → no `UnmarshalJSON` change).

The generated file was hand-applied consistently with the custom JSON because the generator's firmware-JAR download isn't reachable from this environment; `go build` / `go test ./...` pass.