### PR TITLE
Add complete firewall policy schedule model

### DIFF
--- a/cmd/fields/custom/FirewallPolicy.json
+++ b/cmd/fields/custom/FirewallPolicy.json
@@ -42,7 +42,9 @@
   "protocol": "all|tcp|udp|tcp_udp",
   "schedule": {
     "date": "",
-    "mode": "ALWAYS|EVERY_DAY|EVERY_WEEK|ONE_TIME_ONLY",
+    "date_start": "",
+    "date_end": "",
+    "mode": "ALWAYS|EVERY_DAY|EVERY_WEEK|ONE_TIME_ONLY|CUSTOM",
     "repeat_on_days": [
       "mon|tue|wed|thu|fri|sat|sun"
     ],

--- a/cmd/fields/main.go
+++ b/cmd/fields/main.go
@@ -201,6 +201,14 @@ func NewResource(structName string, resourcePath string) *ResourceInfo {
 	case resource.StructName == "FirewallPolicy":
 		resource.ResourcePath = "firewall-policies"
 		resource.FieldProcessor = func(name string, f *FieldInfo) error {
+			// time_all_day is semantically different when absent versus false:
+			// most ALWAYS schedules omit it, while legacy schedules can retain an
+			// explicit false value alongside stale timing metadata. Preserve that
+			// wire-level distinction so clients can round-trip or normalize it.
+			if name == "TimeAllDay" {
+				f.OmitEmpty = true
+				f.IsPointer = true
+			}
 			// The source/destination `port` is not a single number: the
 			// firmware stores and expects it as a string, and it may carry a
 			// comma-separated list (e.g. "80,443"). Model it as a string and

--- a/cmd/fields/main_test.go
+++ b/cmd/fields/main_test.go
@@ -55,6 +55,17 @@ func TestFieldInfoFromValidation(t *testing.T) {
 	}
 }
 
+func TestFirewallPolicyTimeAllDayPreservesPresence(t *testing.T) {
+	resource := NewResource("FirewallPolicy", "firewall-policies")
+	fieldInfo, err := resource.fieldInfoFromValidation("time_all_day", "true|false")
+	if err != nil {
+		t.Fatalf("build time_all_day field: %v", err)
+	}
+	if fieldInfo.FieldType != "bool" || !fieldInfo.IsPointer || !fieldInfo.OmitEmpty {
+		t.Fatalf("time_all_day field = %#v, want *bool with omitempty", fieldInfo)
+	}
+}
+
 func TestResourceTypes(t *testing.T) {
 	testData := `
 {

--- a/specification.json
+++ b/specification.json
@@ -2202,6 +2202,18 @@
                   }
                 },
                 {
+                  "name": "date_end",
+                  "string": {
+                    "computed_optional_required": "computed"
+                  }
+                },
+                {
+                  "name": "date_start",
+                  "string": {
+                    "computed_optional_required": "computed"
+                  }
+                },
+                {
                   "name": "mode",
                   "string": {
                     "computed_optional_required": "computed"
@@ -9615,6 +9627,18 @@
                   }
                 },
                 {
+                  "name": "date_end",
+                  "string": {
+                    "computed_optional_required": "computed_optional"
+                  }
+                },
+                {
+                  "name": "date_start",
+                  "string": {
+                    "computed_optional_required": "computed_optional"
+                  }
+                },
+                {
                   "name": "mode",
                   "string": {
                     "computed_optional_required": "computed_optional"
@@ -9632,7 +9656,7 @@
                 {
                   "name": "time_all_day",
                   "bool": {
-                    "computed_optional_required": "optional"
+                    "computed_optional_required": "computed_optional"
                   }
                 },
                 {

--- a/unifi/firewall_policy.generated.go
+++ b/unifi/firewall_policy.generated.go
@@ -119,9 +119,11 @@ func (dst *FirewallPolicyDestination) UnmarshalJSON(b []byte) error {
 
 type FirewallPolicySchedule struct {
 	Date           string   `json:"date,omitempty"`
-	Mode           string   `json:"mode,omitempty"`           // ALWAYS|EVERY_DAY|EVERY_WEEK|ONE_TIME_ONLY
+	DateEnd        string   `json:"date_end,omitempty"`
+	DateStart      string   `json:"date_start,omitempty"`
+	Mode           string   `json:"mode,omitempty"`           // ALWAYS|EVERY_DAY|EVERY_WEEK|ONE_TIME_ONLY|CUSTOM
 	RepeatOnDays   []string `json:"repeat_on_days,omitempty"` // mon|tue|wed|thu|fri|sat|sun
-	TimeAllDay     bool     `json:"time_all_day"`
+	TimeAllDay     *bool    `json:"time_all_day,omitempty"`
 	TimeRangeEnd   string   `json:"time_range_end,omitempty"`
 	TimeRangeStart string   `json:"time_range_start,omitempty"`
 }

--- a/unifi/firewall_policy_schedule_test.go
+++ b/unifi/firewall_policy_schedule_test.go
@@ -1,0 +1,116 @@
+package unifi
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestFirewallPolicyScheduleRoundTripsControllerFields(t *testing.T) {
+	raw := []byte(`{
+		"date":"2026-07-10",
+		"date_start":"2026-07-01",
+		"date_end":"2026-07-31",
+		"mode":"CUSTOM",
+		"repeat_on_days":["mon","wed","fri"],
+		"time_all_day":false,
+		"time_range_start":"09:00",
+		"time_range_end":"17:30"
+	}`)
+
+	var got FirewallPolicySchedule
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal schedule: %v", err)
+	}
+
+	if got.Date != "2026-07-10" {
+		t.Fatalf("Date = %q, want %q", got.Date, "2026-07-10")
+	}
+	if got.DateStart != "2026-07-01" {
+		t.Fatalf("DateStart = %q, want %q", got.DateStart, "2026-07-01")
+	}
+	if got.DateEnd != "2026-07-31" {
+		t.Fatalf("DateEnd = %q, want %q", got.DateEnd, "2026-07-31")
+	}
+	if got.Mode != "CUSTOM" {
+		t.Fatalf("Mode = %q, want %q", got.Mode, "CUSTOM")
+	}
+	if !reflect.DeepEqual(got.RepeatOnDays, []string{"mon", "wed", "fri"}) {
+		t.Fatalf("RepeatOnDays = %#v", got.RepeatOnDays)
+	}
+	if got.TimeAllDay == nil || *got.TimeAllDay {
+		t.Fatalf("TimeAllDay = %v, want pointer to false", got.TimeAllDay)
+	}
+	if got.TimeRangeStart != "09:00" || got.TimeRangeEnd != "17:30" {
+		t.Fatalf("time range = %q-%q", got.TimeRangeStart, got.TimeRangeEnd)
+	}
+
+	roundTripped, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal schedule: %v", err)
+	}
+
+	var wantObject, gotObject map[string]any
+	if err := json.Unmarshal(raw, &wantObject); err != nil {
+		t.Fatalf("decode expected JSON: %v", err)
+	}
+	if err := json.Unmarshal(roundTripped, &gotObject); err != nil {
+		t.Fatalf("decode round-tripped JSON: %v", err)
+	}
+	if !reflect.DeepEqual(gotObject, wantObject) {
+		t.Fatalf("round-trip mismatch:\n got: %s\nwant: %s", roundTripped, raw)
+	}
+}
+
+func TestFirewallPolicySchedulePreservesLegacyFieldsUnderAlways(t *testing.T) {
+	raw := []byte(`{
+		"date_start":"2025-06-20",
+		"date_end":"2025-06-27",
+		"mode":"ALWAYS",
+		"repeat_on_days":[],
+		"time_all_day":false,
+		"time_range_start":"09:00",
+		"time_range_end":"12:00"
+	}`)
+
+	var schedule FirewallPolicySchedule
+	if err := json.Unmarshal(raw, &schedule); err != nil {
+		t.Fatalf("unmarshal schedule: %v", err)
+	}
+	roundTripped, err := json.Marshal(schedule)
+	if err != nil {
+		t.Fatalf("marshal schedule: %v", err)
+	}
+
+	var got FirewallPolicySchedule
+	if err := json.Unmarshal(roundTripped, &got); err != nil {
+		t.Fatalf("decode round-tripped schedule: %v", err)
+	}
+	if got.Mode != "ALWAYS" ||
+		got.DateStart != "2025-06-20" || got.DateEnd != "2025-06-27" ||
+		got.TimeAllDay == nil || *got.TimeAllDay ||
+		got.TimeRangeStart != "09:00" || got.TimeRangeEnd != "12:00" ||
+		len(got.RepeatOnDays) != 0 {
+		t.Fatalf("legacy schedule semantics changed: %#v", got)
+	}
+}
+
+func TestFirewallPolicySchedulePreservesAbsentTimeAllDay(t *testing.T) {
+	raw := []byte(`{"mode":"ALWAYS"}`)
+
+	var schedule FirewallPolicySchedule
+	if err := json.Unmarshal(raw, &schedule); err != nil {
+		t.Fatalf("unmarshal schedule: %v", err)
+	}
+	if schedule.TimeAllDay != nil {
+		t.Fatalf("TimeAllDay = %v, want nil", schedule.TimeAllDay)
+	}
+
+	roundTripped, err := json.Marshal(schedule)
+	if err != nil {
+		t.Fatalf("marshal schedule: %v", err)
+	}
+	if string(roundTripped) != string(raw) {
+		t.Fatalf("round-trip = %s, want %s", roundTripped, raw)
+	}
+}


### PR DESCRIPTION
## Changes

UniFi's zone-based firewall API returns more schedule information than the SDK currently models. This adds the missing date fields and `CUSTOM` mode, and makes `time_all_day` nullable so JSON can round-trip without changing its meaning.

The nullable boolean is the kinda awkward but important part here. Controllers distinguish between an omitted `time_all_day`, an explicit `false`, and an explicit `true`. Using a plain `bool` collapses the first two cases, which means reading and later writing an existing policy would potentially invisibly change the schedule.

### Breaking changes

This changss `FirewallPolicySchedule.TimeAllDay` from `bool` to `*bool`, so it is a source-breaking change for callers that construct this struct directly. I left the PR as a draft so that more experienced maintainers can weigh the tradeoff and because it's my first time contributing, but I'm using it with my own setup. I couldn't find a way to preserve all three wire states without changing the type, but maybe someone smarter than me can.

## Testing

I added JSON round-trip coverage for complete `CUSTOM` schedules as well as canonical and legacy `ALWAYS` payloads. The generator test also checks that the field remains `*bool` with `omitempty`.

The rest of the testing was made by me, since I am actually using this change in my environment.

This is the SDK half of the related Terraform provider change in ubiquiti-community/terraform-provider-unifi#368.
