### PR TITLE
feat: recover CSRF token from UniFi OS JWT cookie when header absent

### DIFF
--- a/unifi/csrf_jwt_test.go
+++ b/unifi/csrf_jwt_test.go
@@ -1,0 +1,273 @@
+package unifi
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// jwtWith builds a fake JWT ("hdr.<payload>.sig") whose payload carries the
+// given csrfToken claim.
+func jwtWith(csrf string) string {
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"csrfToken":"` + csrf + `"}`))
+	return "hdr." + payload + ".sig"
+}
+
+// jwtWithExp is jwtWith plus a standard exp claim (epoch seconds).
+func jwtWithExp(csrf string, exp int64) string {
+	payload := base64.RawURLEncoding.EncodeToString(
+		[]byte(fmt.Sprintf(`{"csrfToken":%q,"exp":%d}`, csrf, exp)),
+	)
+	return "hdr." + payload + ".sig"
+}
+
+// TestLogin_CSRFFromJWTCookieWhenHeaderAbsent proves login succeeds against
+// UniFi OS builds that return the CSRF token only inside the TOKEN cookie's
+// JWT and omit the X-Csrf-Token response header. The client must recover the
+// token from the cookie (isLoggedIn requires a non-empty CSRF token on
+// new-style controllers, so without recovery login fails outright) and send
+// it on subsequent requests.
+func TestLogin_CSRFFromJWTCookieWhenHeaderAbsent(t *testing.T) {
+	shortLoginBackoff(t)
+
+	var lastSeenCSRF string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if handleNewStyleSetup(w, r) {
+			return
+		}
+		if r.Method == http.MethodPost && r.URL.Path == loginPathNew {
+			// Deliberately no X-Csrf-Token header: the token travels only in
+			// the JWT cookie, as some UniFi OS builds do.
+			http.SetCookie(w, &http.Cookie{Name: "TOKEN", Value: jwtWith("cookie-csrf")})
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.URL.Path == "/proxy/network/api/s/default/self" {
+			lastSeenCSRF = r.Header.Get("X-Csrf-Token")
+			_, _ = w.Write([]byte(`{"meta":{"rc":"ok"},"data":[]}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c, err := New(context.Background(), &Config{
+		BaseURL:  srv.URL,
+		Username: "admin",
+		Password: "admin",
+	})
+	if err != nil {
+		t.Fatalf("login should succeed via JWT-cookie CSRF recovery, got: %v", err)
+	}
+
+	if err := c.do(context.Background(), http.MethodGet, "api/s/default/self", nil, nil); err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	if lastSeenCSRF != "cookie-csrf" {
+		t.Errorf("expected X-Csrf-Token %q on follow-up request, got %q", "cookie-csrf", lastSeenCSRF)
+	}
+}
+
+// TestLogin_CSRFHeaderTakesPrecedenceOverCookie verifies the existing header
+// behavior is unchanged: when a response carries both an X-Csrf-Token header
+// and a JWT cookie, the header wins.
+func TestLogin_CSRFHeaderTakesPrecedenceOverCookie(t *testing.T) {
+	var lastSeenCSRF string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if handleNewStyleSetup(w, r) {
+			return
+		}
+		if r.Method == http.MethodPost && r.URL.Path == loginPathNew {
+			http.SetCookie(w, &http.Cookie{Name: "TOKEN", Value: jwtWith("cookie-csrf")})
+			w.Header().Set("X-Csrf-Token", "header-csrf")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.URL.Path == "/proxy/network/api/s/default/self" {
+			lastSeenCSRF = r.Header.Get("X-Csrf-Token")
+			_, _ = w.Write([]byte(`{"meta":{"rc":"ok"},"data":[]}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c, err := New(context.Background(), &Config{
+		BaseURL:  srv.URL,
+		Username: "admin",
+		Password: "admin",
+	})
+	if err != nil {
+		t.Fatalf("unexpected login error: %v", err)
+	}
+
+	if err := c.do(context.Background(), http.MethodGet, "api/s/default/self", nil, nil); err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	if lastSeenCSRF != "header-csrf" {
+		t.Errorf("expected header token to win, got X-Csrf-Token %q", lastSeenCSRF)
+	}
+}
+
+// TestCSRFFromJWTCookie exercises the claim extraction against well-formed and
+// malformed cookie values.
+func TestCSRFFromJWTCookie(t *testing.T) {
+	noClaim := "hdr." + base64.RawURLEncoding.EncodeToString([]byte(`{"userId":"u"}`)) + ".sig"
+
+	cases := []struct {
+		name    string
+		cookies []*http.Cookie
+		want    string
+		wantExp time.Time
+	}{
+		{"TOKEN cookie with claim", []*http.Cookie{{Name: "TOKEN", Value: jwtWith("abc")}}, "abc", time.Time{}},
+		{"UOS_TOKEN cookie with claim", []*http.Cookie{{Name: "UOS_TOKEN", Value: jwtWith("xyz")}}, "xyz", time.Time{}},
+		{"claim with exp", []*http.Cookie{{Name: "TOKEN", Value: jwtWithExp("abc", 1786000000)}}, "abc", time.Unix(1786000000, 0)},
+		{"unrelated cookie name ignored", []*http.Cookie{{Name: "unifises", Value: jwtWith("abc")}}, "", time.Time{}},
+		{"not a JWT", []*http.Cookie{{Name: "TOKEN", Value: "opaque-session-id"}}, "", time.Time{}},
+		{"bad base64 payload", []*http.Cookie{{Name: "TOKEN", Value: "hdr.!!!.sig"}}, "", time.Time{}},
+		{"no csrfToken claim", []*http.Cookie{{Name: "TOKEN", Value: noClaim}}, "", time.Time{}},
+		{"no cookies", nil, "", time.Time{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, gotExp := csrfFromJWTCookie(tc.cookies)
+			if got != tc.want {
+				t.Errorf("csrfFromJWTCookie() token = %q, want %q", got, tc.want)
+			}
+			if !gotExp.Equal(tc.wantExp) {
+				t.Errorf("csrfFromJWTCookie() exp = %v, want %v", gotExp, tc.wantExp)
+			}
+		})
+	}
+}
+
+// TestRelogin_PurgesStaleUOSTokenCookie verifies that a re-login does not send
+// a stale UOS_TOKEN session cookie: controllers that name their session cookie
+// UOS_TOKEN error out when a login request carries the expired token.
+func TestRelogin_PurgesStaleUOSTokenCookie(t *testing.T) {
+	shortLoginBackoff(t)
+
+	var loginCookies []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if handleNewStyleSetup(w, r) {
+			return
+		}
+		if r.Method == http.MethodPost && r.URL.Path == loginPathNew {
+			names := make([]string, 0, len(r.Cookies()))
+			for _, ck := range r.Cookies() {
+				names = append(names, ck.Name)
+			}
+			loginCookies = append(loginCookies, strings.Join(names, ","))
+			// Path=/ as real UniFi OS controllers set it; the purge relies on it.
+			http.SetCookie(w, &http.Cookie{Name: "UOS_TOKEN", Value: jwtWith("cookie-csrf"), Path: "/"})
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c, err := New(context.Background(), &Config{
+		BaseURL:  srv.URL,
+		Username: "admin",
+		Password: "admin",
+	})
+	if err != nil {
+		t.Fatalf("unexpected login error: %v", err)
+	}
+
+	// Force a re-login with the previous session's UOS_TOKEN still in the jar.
+	if err := c.login(context.Background()); err != nil {
+		t.Fatalf("unexpected re-login error: %v", err)
+	}
+
+	if len(loginCookies) != 2 {
+		t.Fatalf("expected 2 login requests, saw %d", len(loginCookies))
+	}
+	if strings.Contains(loginCookies[1], "UOS_TOKEN") {
+		t.Errorf("re-login request still carried the stale UOS_TOKEN cookie (cookies: %q)", loginCookies[1])
+	}
+}
+
+// TestLogin_JWTCookieExpTracksTokenExpiry verifies that when the CSRF token is
+// recovered from the JWT cookie and the response has no X-Token-Expire-Time
+// header, the JWT's exp claim drives session-expiry tracking.
+func TestLogin_JWTCookieExpTracksTokenExpiry(t *testing.T) {
+	shortLoginBackoff(t)
+
+	exp := time.Now().Add(2 * time.Hour).Unix()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if handleNewStyleSetup(w, r) {
+			return
+		}
+		if r.Method == http.MethodPost && r.URL.Path == loginPathNew {
+			http.SetCookie(w, &http.Cookie{Name: "TOKEN", Value: jwtWithExp("cookie-csrf", exp)})
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c, err := New(context.Background(), &Config{
+		BaseURL:  srv.URL,
+		Username: "admin",
+		Password: "admin",
+	})
+	if err != nil {
+		t.Fatalf("unexpected login error: %v", err)
+	}
+
+	if !c.tokenExpiry.Equal(time.Unix(exp, 0)) {
+		t.Errorf("tokenExpiry = %v, want %v (from the JWT exp claim)", c.tokenExpiry, time.Unix(exp, 0))
+	}
+}
+
+// TestConcurrentRequestsCSRFTokenRace drives parallel requests against a
+// controller that re-issues the TOKEN cookie on every response, so the CSRF
+// capture path runs concurrently under the loginMu read lock. Run with -race.
+func TestConcurrentRequestsCSRFTokenRace(t *testing.T) {
+	shortLoginBackoff(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if handleNewStyleSetup(w, r) {
+			return
+		}
+		if r.Method == http.MethodPost && r.URL.Path == loginPathNew {
+			http.SetCookie(w, &http.Cookie{Name: "TOKEN", Value: jwtWith("csrf-0")})
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		// Re-issue the session cookie on every data response, as UniFi OS does.
+		http.SetCookie(w, &http.Cookie{Name: "TOKEN", Value: jwtWith("csrf-" + r.URL.Query().Get("i"))})
+		_, _ = w.Write([]byte(`{"meta":{"rc":"ok"},"data":[]}`))
+	}))
+	defer srv.Close()
+
+	c, err := New(context.Background(), &Config{
+		BaseURL:  srv.URL,
+		Username: "admin",
+		Password: "admin",
+	})
+	if err != nil {
+		t.Fatalf("unexpected login error: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for i := range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = c.do(context.Background(), http.MethodGet, "api/s/default/self", nil, nil,
+				map[string]string{"i": fmt.Sprint(i)})
+		}()
+	}
+	wg.Wait()
+}

--- a/unifi/unifi.go
+++ b/unifi/unifi.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -190,6 +191,7 @@ type ApiClient struct {
 	loginPath string
 	apiPath   string // path to API, e.g. "proxy/network" for new style API, "/api" for old style API
 
+	csrfMu      sync.Mutex // guards csrf and tokenExpiry, which concurrent requests update under the loginMu read lock
 	csrf        string
 	tokenExpiry time.Time
 	loginErr    error // cached login error to prevent retry storms
@@ -216,9 +218,18 @@ func (c *ApiClient) isNewStyle() bool {
 // For standalone (old-style): checks the cookiejar for a unifises session cookie.
 func (c *ApiClient) isLoggedIn() bool {
 	if c.isNewStyle() {
+		c.csrfMu.Lock()
+		defer c.csrfMu.Unlock()
 		return c.csrf != ""
 	}
 	return c.hasCookie("unifises")
+}
+
+// sessionExpired reports whether the tracked session expiry has passed.
+func (c *ApiClient) sessionExpired() bool {
+	c.csrfMu.Lock()
+	defer c.csrfMu.Unlock()
+	return !c.tokenExpiry.IsZero() && time.Now().After(c.tokenExpiry)
 }
 
 // hasCookie checks if the cookiejar contains a cookie with the given name.
@@ -229,6 +240,40 @@ func (c *ApiClient) hasCookie(name string) bool {
 	return slices.ContainsFunc(c.c.HTTPClient.Jar.Cookies(c.baseURL), func(cookie *http.Cookie) bool {
 		return cookie.Name == name
 	})
+}
+
+// csrfFromJWTCookie extracts the csrfToken claim from a UniFi OS auth cookie
+// (TOKEN or UOS_TOKEN), whose value is a JWT, along with the token expiry from
+// the standard exp claim (zero when absent). Some UniFi OS builds return the
+// CSRF token only in this cookie, not in a response header. No signature
+// verification is performed — this is the client's own session cookie and only
+// individual claims are read from it.
+func csrfFromJWTCookie(cookies []*http.Cookie) (string, time.Time) {
+	for _, ck := range cookies {
+		if ck.Name != "TOKEN" && ck.Name != "UOS_TOKEN" {
+			continue
+		}
+		parts := strings.Split(ck.Value, ".")
+		if len(parts) < 2 {
+			continue
+		}
+		payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+		if err != nil {
+			continue
+		}
+		var claims struct {
+			CSRFToken string `json:"csrfToken"`
+			Exp       int64  `json:"exp"`
+		}
+		if json.Unmarshal(payload, &claims) == nil && claims.CSRFToken != "" {
+			var exp time.Time
+			if claims.Exp > 0 {
+				exp = time.Unix(claims.Exp, 0)
+			}
+			return claims.CSRFToken, exp
+		}
+	}
+	return "", time.Time{}
 }
 
 func (c *ApiClient) setBaseURL(base string) error {
@@ -431,10 +476,13 @@ func (c *ApiClient) login(ctx context.Context) error {
 	if c.baseURL != nil {
 		c.c.HTTPClient.Jar.SetCookies(c.baseURL, []*http.Cookie{
 			{Name: "TOKEN", MaxAge: -1},
+			{Name: "UOS_TOKEN", MaxAge: -1},
 			{Name: "unifises", MaxAge: -1},
 		})
 	}
+	c.csrfMu.Lock()
 	c.csrf = ""
+	c.csrfMu.Unlock()
 
 	// Call doRequest directly to avoid login-check recursion and deadlock on loginMu.
 	err := c.doRequest(ctx, http.MethodPost, c.loginPath, &struct {
@@ -516,7 +564,7 @@ func (c *ApiClient) ensureLoggedIn(ctx context.Context) error {
 	defer c.loginMu.Unlock()
 
 	// Double-check: another goroutine may have already logged in while we waited.
-	if c.isLoggedIn() && (c.tokenExpiry.IsZero() || time.Now().Before(c.tokenExpiry)) {
+	if c.isLoggedIn() && !c.sessionExpired() {
 		return nil
 	}
 
@@ -575,7 +623,7 @@ func (c *ApiClient) do(
 	if c.apiKey == "" && c.username != "" && c.password != "" {
 		// Wait for any in-progress login to complete, then check if we need to login.
 		c.loginMu.RLock()
-		needsLogin := !c.isLoggedIn() || (!c.tokenExpiry.IsZero() && time.Now().After(c.tokenExpiry))
+		needsLogin := !c.isLoggedIn() || c.sessionExpired()
 		c.loginMu.RUnlock()
 
 		if needsLogin {
@@ -662,8 +710,11 @@ func (c *ApiClient) doRequest(
 	if c.apiKey != "" {
 		req.Header.Set("X-Api-Key", c.apiKey)
 	}
-	if c.csrf != "" {
-		req.Header.Set("X-Csrf-Token", c.csrf)
+	c.csrfMu.Lock()
+	csrfToken := c.csrf
+	c.csrfMu.Unlock()
+	if csrfToken != "" {
+		req.Header.Set("X-Csrf-Token", csrfToken)
 	}
 
 	resp, err := c.c.Do(req)
@@ -689,16 +740,29 @@ func (c *ApiClient) doRequest(
 		return &RateLimitError{RetryAfter: parseRetryAfter(resp)}
 	}
 
+	c.csrfMu.Lock()
 	if csrf := resp.Header.Get("X-Updated-Csrf-Token"); csrf != "" {
 		c.csrf = csrf
 	} else if csrf := resp.Header.Get("X-Csrf-Token"); csrf != "" {
 		c.csrf = csrf
+	} else if csrf, exp := csrfFromJWTCookie(resp.Cookies()); csrf != "" {
+		// Some UniFi OS builds omit the CSRF response headers and return the
+		// token only inside the TOKEN/UOS_TOKEN JWT cookie. Without this
+		// fallback, login on those builds never establishes a session
+		// (isLoggedIn requires a non-empty CSRF token on new-style
+		// controllers). The JWT's exp claim drives expiry tracking on these
+		// builds, which also omit X-Token-Expire-Time.
+		c.csrf = csrf
+		if !exp.IsZero() {
+			c.tokenExpiry = exp
+		}
 	}
 	if exp := resp.Header.Get("X-Token-Expire-Time"); exp != "" {
 		if ms, err := strconv.ParseInt(exp, 10, 64); err == nil {
 			c.tokenExpiry = time.UnixMilli(ms)
 		}
 	}
+	c.csrfMu.Unlock()
 
 	successCodes := []int{http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent}
 	if !slices.Contains(successCodes, resp.StatusCode) {


### PR DESCRIPTION
## Problem

Some UniFi OS builds never send an `X-Csrf-Token` (or `X-Updated-Csrf-Token`) response header — they return the CSRF token only as a claim inside the `TOKEN`/`UOS_TOKEN` JWT session cookie. Because `isLoggedIn()` requires a non-empty `csrf` on new-style controllers, login against those builds fails outright today with `login response did not establish a session` (reproduced in the new regression test).

## Fix

- `csrfFromJWTCookie`: decodes the JWT payload of a `TOKEN`/`UOS_TOKEN` cookie (no signature verification — it is our own session cookie and we read two claims) and returns the `csrfToken` claim plus the standard `exp` claim.
- Wired into the response-capture chain as the lowest-precedence source: `X-Updated-Csrf-Token` > `X-Csrf-Token` > JWT-cookie claim. The `exp` claim feeds `tokenExpiry` (the `X-Token-Expire-Time` header still overrides when present), so cookie-only sessions get expiry tracking too.
- `login()`'s stale-cookie purge now also expires `UOS_TOKEN` (previously only `TOKEN`/`unifises`), so re-login on those controllers doesn't send a stale JWT.
- While touching this path: `csrf`/`tokenExpiry` are written during concurrent requests that share `loginMu.RLock`, which raced; they now have a leaf-level `csrfMu` (consistent `loginMu → csrfMu` order, never held across another lock). `go test -race` showed 1 data-race warning before, 0 after.

## Verification

TDD throughout — key tests: `TestLogin_CSRFFromJWTCookieWhenHeaderAbsent` (the login-blocking regression), `TestLogin_CSRFHeaderTakesPrecedenceOverCookie` (existing behavior unchanged), a 7-case table for malformed cookies (non-JWT, bad base64, claim-less → ignored), `TestRelogin_PurgesStaleUOSTokenCookie`, `TestLogin_JWTCookieExpTracksTokenExpiry`, and `TestConcurrentRequestsCSRFTokenRace` under `-race`. `go build`, full `go test`, `go test -race ./unifi/`, `gofmt`, golangci-lint v2: clean, no new issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
