### PR TITLE
feat: add AuthorizeClientByMAC guest authorization (authorize-guest)

### DIFF
--- a/unifi/client.go
+++ b/unifi/client.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"net/http"
 	"slices"
+	"strconv"
 )
 
 // GetClientByMAC returns slightly different information than GetClient, as they
@@ -27,11 +28,14 @@ func (c *ApiClient) GetClientByMAC(ctx context.Context, site, mac string) (*Clie
 	}
 }
 
-func (c *ApiClient) stamgr(
+// stamgrMeta issues a station-manager command and returns the response rc
+// alongside the client data, so callers can distinguish a genuine miss from a
+// success that echoed no client object.
+func (c *ApiClient) stamgrMeta(
 	ctx context.Context,
 	site, cmd string,
 	data map[string]any,
-) ([]Client, error) {
+) (string, []Client, error) {
 	reqBody := map[string]any{}
 
 	maps.Copy(reqBody, data)
@@ -45,10 +49,47 @@ func (c *ApiClient) stamgr(
 
 	err := c.do(ctx, http.MethodPost, fmt.Sprintf("api/s/%s/cmd/stamgr", site), reqBody, &respBody)
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
 
-	return respBody.Data, nil
+	return respBody.Meta.RC, respBody.Data, nil
+}
+
+func (c *ApiClient) stamgr(
+	ctx context.Context,
+	site, cmd string,
+	data map[string]any,
+) ([]Client, error) {
+	_, clients, err := c.stamgrMeta(ctx, site, cmd, data)
+	return clients, err
+}
+
+// AuthorizeClientByMAC authorizes a guest WiFi session by MAC via the
+// authorize-guest station-manager command. minutes must be a decimal integer
+// string (e.g. "480"); it is sent to the controller as a JSON number so the
+// session expiry is honoured. If minutes is empty or unparseable the field is
+// omitted and the controller applies its own default (typically unlimited).
+// Some UniFi OS builds answer authorize-guest with rc:"ok" and an empty data
+// array even though the client was authorized, so unlike the other station
+// commands an empty reply is treated as success.
+func (c *ApiClient) AuthorizeClientByMAC(ctx context.Context, site, mac, apMAC, minutes string) error {
+	params := map[string]any{
+		"ap_mac": apMAC,
+		"mac":    mac,
+	}
+	if m, err := strconv.Atoi(minutes); err == nil && m > 0 {
+		params["minutes"] = m
+	}
+
+	rc, clients, err := c.stamgrMeta(ctx, site, "authorize-guest", params)
+	if err != nil {
+		return err
+	}
+	if rc == "ok" && len(clients) <= 1 {
+		return nil
+	}
+
+	return &NotFoundError{}
 }
 
 func (c *ApiClient) BlockClientByMAC(ctx context.Context, site, mac string) error {

--- a/unifi/client_authorize_test.go
+++ b/unifi/client_authorize_test.go
@@ -1,0 +1,152 @@
+package unifi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// stamgrTestServer stands up a new-style (UniFi OS) controller whose stamgr
+// endpoint replies with the given status and body, capturing the last request
+// body it received so tests can assert on the exact wire format.
+func stamgrTestServer(t *testing.T, site string, status int, respJSON string) (*httptest.Server, *map[string]any) {
+	t.Helper()
+	lastBody := &map[string]any{}
+	stamgrPath := "/proxy/network/api/s/" + site + "/cmd/stamgr"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if handleNewStyleSetup(w, r) {
+			return
+		}
+		if r.Method == http.MethodPost && r.URL.Path == loginPathNew {
+			w.Header().Set("X-Csrf-Token", "tok")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.Method == http.MethodPost && r.URL.Path == stamgrPath {
+			body := map[string]any{}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			*lastBody = body
+			w.Header().Set("Content-Type", "application/json")
+			if status != http.StatusOK {
+				w.WriteHeader(status)
+			}
+			_, _ = w.Write([]byte(respJSON))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, lastBody
+}
+
+func newStamgrTestClient(t *testing.T, srv *httptest.Server) *ApiClient {
+	t.Helper()
+	c, err := New(context.Background(), &Config{BaseURL: srv.URL, Username: "admin", Password: "admin"})
+	if err != nil {
+		t.Fatalf("client init: %v", err)
+	}
+	return c
+}
+
+// TestAuthorizeClientByMAC_Success covers the classic controller reply where
+// the authorized client object is echoed back in data.
+func TestAuthorizeClientByMAC_Success(t *testing.T) {
+	srv, lastBody := stamgrTestServer(t, "default", http.StatusOK,
+		`{"meta":{"rc":"ok"},"data":[{"mac":"aa:bb:cc:dd:ee:ff"}]}`)
+	c := newStamgrTestClient(t, srv)
+
+	err := c.AuthorizeClientByMAC(context.Background(), "default", "aa:bb:cc:dd:ee:ff", "11:22:33:44:55:66", "480")
+	if err != nil {
+		t.Fatalf("AuthorizeClientByMAC errored: %v", err)
+	}
+
+	body := *lastBody
+	if body["cmd"] != "authorize-guest" {
+		t.Errorf("cmd = %v, want authorize-guest", body["cmd"])
+	}
+	if body["mac"] != "aa:bb:cc:dd:ee:ff" {
+		t.Errorf("mac = %v, want aa:bb:cc:dd:ee:ff", body["mac"])
+	}
+	if body["ap_mac"] != "11:22:33:44:55:66" {
+		t.Errorf("ap_mac = %v, want 11:22:33:44:55:66", body["ap_mac"])
+	}
+	// The controller rejects string minutes: the value must be a JSON number.
+	if m, ok := body["minutes"].(float64); !ok || m != 480 {
+		t.Errorf("minutes = %v (%T), want JSON number 480", body["minutes"], body["minutes"])
+	}
+}
+
+// TestAuthorizeClientByMAC_EmptyDataOK locks in the fix for UniFi OS builds
+// that answer authorize-guest with rc:"ok" and an empty data array even though
+// the client was authorized; the naive len(users)!=1 check misreads that as
+// not-found.
+func TestAuthorizeClientByMAC_EmptyDataOK(t *testing.T) {
+	srv, _ := stamgrTestServer(t, "default", http.StatusOK,
+		`{"meta":{"rc":"ok"},"data":[]}`)
+	c := newStamgrTestClient(t, srv)
+
+	err := c.AuthorizeClientByMAC(context.Background(), "default", "aa:bb:cc:dd:ee:ff", "", "")
+	if err != nil {
+		t.Fatalf("rc:ok with empty data should be success, got: %v", err)
+	}
+}
+
+// TestAuthorizeClientByMAC_OmitsUnparseableMinutes verifies that an empty or
+// non-numeric minutes value is omitted so the controller applies its default.
+func TestAuthorizeClientByMAC_OmitsUnparseableMinutes(t *testing.T) {
+	srv, lastBody := stamgrTestServer(t, "default", http.StatusOK,
+		`{"meta":{"rc":"ok"},"data":[]}`)
+	c := newStamgrTestClient(t, srv)
+
+	if err := c.AuthorizeClientByMAC(context.Background(), "default", "aa:bb:cc:dd:ee:ff", "", "unlimited"); err != nil {
+		t.Fatalf("AuthorizeClientByMAC errored: %v", err)
+	}
+	if _, present := (*lastBody)["minutes"]; present {
+		t.Errorf("minutes should be omitted for unparseable input, body = %v", *lastBody)
+	}
+}
+
+// TestAuthorizeClientByMAC_APIError surfaces a controller error response.
+func TestAuthorizeClientByMAC_APIError(t *testing.T) {
+	srv, _ := stamgrTestServer(t, "default", http.StatusBadRequest,
+		`{"meta":{"rc":"error","msg":"api.err.UnknownStation"},"data":[]}`)
+	c := newStamgrTestClient(t, srv)
+
+	err := c.AuthorizeClientByMAC(context.Background(), "default", "aa:bb:cc:dd:ee:ff", "", "60")
+	if err == nil {
+		t.Fatal("expected error from rc:error response, got nil")
+	}
+}
+
+// TestAuthorizeClientByMAC_MultipleClientsNotFound treats an ambiguous reply
+// (more than one client echoed) as not-found, mirroring the other stamgr
+// commands.
+func TestAuthorizeClientByMAC_MultipleClientsNotFound(t *testing.T) {
+	srv, _ := stamgrTestServer(t, "default", http.StatusOK,
+		`{"meta":{"rc":"ok"},"data":[{"mac":"aa:aa:aa:aa:aa:aa"},{"mac":"bb:bb:bb:bb:bb:bb"}]}`)
+	c := newStamgrTestClient(t, srv)
+
+	err := c.AuthorizeClientByMAC(context.Background(), "default", "aa:bb:cc:dd:ee:ff", "", "")
+	var nf *NotFoundError
+	if !errors.As(err, &nf) {
+		t.Fatalf("expected NotFoundError for ambiguous reply, got: %v", err)
+	}
+}
+
+// TestStamgrExistingCommandsUnchanged pins the pre-existing single-client
+// contract of the other stamgr commands: an empty data array stays not-found
+// for them (only authorize-guest is exempt).
+func TestStamgrExistingCommandsUnchanged(t *testing.T) {
+	srv, _ := stamgrTestServer(t, "default", http.StatusOK,
+		`{"meta":{"rc":"ok"},"data":[]}`)
+	c := newStamgrTestClient(t, srv)
+
+	err := c.BlockClientByMAC(context.Background(), "default", "aa:bb:cc:dd:ee:ff")
+	var nf *NotFoundError
+	if !errors.As(err, &nf) {
+		t.Fatalf("BlockClientByMAC with empty data should stay NotFoundError, got: %v", err)
+	}
+}


### PR DESCRIPTION
## What

Adds `AuthorizeClientByMAC(ctx, site, mac, apMAC, minutes)` — guest/captive-portal authorization via `cmd:authorize-guest` on `s/{site}/cmd/stamgr` — following the existing `…ClientByMAC` naming and parameter conventions.

Two controller quirks are handled, both battle-tested in britannic/go-unifi:

- `minutes` must serialize as a JSON **number**; controllers reject string values. Coerced via `strconv.Atoi`, omitted when empty/unparseable.
- Some UniFi OS builds return `{"meta":{"rc":"ok"},"data":[]}` for a successful authorize-guest. The existing stamgr plumbing (`len(users) != 1` → `NotFoundError`) would misreport that success as a failure, so this command gets scoped rc:ok-empty-data success handling — via a `stamgrMeta` helper that the existing `stamgr` now delegates to. Block/Unblock/Kick/Delete semantics are byte-identical (guarded by `TestStamgrExistingCommandsUnchanged`).

## Verification

TDD; 6 tests including wire-format assertions on the captured request body (minutes as number, omission case), the empty-data success case, rc:error surfacing, and multi-client `NotFoundError`. `go build`, full `go test`, `gofmt`, golangci-lint v2: clean, no new issues.

While in this file, one observation (pre-existing, untouched): `GetClientByMAC`'s list-scan returns the first match and ignores pagination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
