### PR TITLE
feat: add GetHealth client method for site health metrics (stat/health)

### DIFF
--- a/unifi/site_health.go
+++ b/unifi/site_health.go
@@ -1,0 +1,93 @@
+package unifi
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/ubiquiti-community/go-unifi/unifi/types"
+)
+
+// SiteHealthGwSystemStats holds gateway system statistics reported by the
+// health endpoint.
+type SiteHealthGwSystemStats struct {
+	CPU    types.Number `json:"cpu"`
+	Mem    types.Number `json:"mem"`
+	Uptime types.Number `json:"uptime"`
+}
+
+// SiteHealth is one per-subsystem entry from the site health endpoint
+// (subsystems include wan, lan, wlan, www, vpn).
+type SiteHealth struct {
+	Subsystem string `json:"subsystem"`
+	Status    string `json:"status"`
+
+	NumUser  types.Number `json:"num_user,omitempty"`
+	NumGuest types.Number `json:"num_guest,omitempty"`
+	NumIot   types.Number `json:"num_iot,omitempty"`
+	TxBytesR types.Number `json:"tx_bytes-r,omitempty"`
+	RxBytesR types.Number `json:"rx_bytes-r,omitempty"`
+
+	NumAp           types.Number `json:"num_ap,omitempty"`
+	NumAdopted      types.Number `json:"num_adopted,omitempty"`
+	NumDisabled     types.Number `json:"num_disabled,omitempty"`
+	NumDisconnected types.Number `json:"num_disconnected,omitempty"`
+	NumPending      types.Number `json:"num_pending,omitempty"`
+	NumGw           types.Number `json:"num_gw,omitempty"`
+	NumSw           types.Number `json:"num_sw,omitempty"`
+	NumSta          types.Number `json:"num_sta,omitempty"`
+
+	WanIP         string                  `json:"wan_ip,omitempty"`
+	Gateways      []string                `json:"gateways,omitempty"`
+	Netmask       string                  `json:"netmask,omitempty"`
+	Nameservers   []string                `json:"nameservers,omitempty"`
+	GwMac         string                  `json:"gw_mac,omitempty"`
+	GwName        string                  `json:"gw_name,omitempty"`
+	GwSystemStats SiteHealthGwSystemStats `json:"gw_system-stats,omitempty"`
+	GwVersion     string                  `json:"gw_version,omitempty"`
+	LanIP         string                  `json:"lan_ip,omitempty"`
+
+	Latency          types.Number `json:"latency,omitempty"`
+	Uptime           types.Number `json:"uptime,omitempty"`
+	Drops            types.Number `json:"drops,omitempty"`
+	XputUp           types.Number `json:"xput_up,omitempty"`
+	XputDown         types.Number `json:"xput_down,omitempty"`
+	SpeedtestStatus  string       `json:"speedtest_status,omitempty"`
+	SpeedtestLastrun types.Number `json:"speedtest_lastrun,omitempty"`
+	SpeedtestPing    types.Number `json:"speedtest_ping,omitempty"`
+
+	RemoteUserEnabled     bool         `json:"remote_user_enabled,omitempty"`
+	RemoteUserNumActive   types.Number `json:"remote_user_num_active,omitempty"`
+	RemoteUserNumInactive types.Number `json:"remote_user_num_inactive,omitempty"`
+	RemoteUserRxBytes     types.Number `json:"remote_user_rx_bytes,omitempty"`
+	RemoteUserTxBytes     types.Number `json:"remote_user_tx_bytes,omitempty"`
+	RemoteUserRxPackets   types.Number `json:"remote_user_rx_packets,omitempty"`
+	RemoteUserTxPackets   types.Number `json:"remote_user_tx_packets,omitempty"`
+
+	SiteToSiteEnabled     bool         `json:"site_to_site_enabled,omitempty"`
+	SiteToSiteNumActive   types.Number `json:"site_to_site_num_active,omitempty"`
+	SiteToSiteNumInactive types.Number `json:"site_to_site_num_inactive,omitempty"`
+	SiteToSiteRxBytes     types.Number `json:"site_to_site_rx_bytes,omitempty"`
+	SiteToSiteTxBytes     types.Number `json:"site_to_site_tx_bytes,omitempty"`
+	SiteToSiteRxPackets   types.Number `json:"site_to_site_rx_packets,omitempty"`
+	SiteToSiteTxPackets   types.Number `json:"site_to_site_tx_packets,omitempty"`
+}
+
+// GetHealth returns the per-subsystem health metrics for a site.
+func (c *ApiClient) GetHealth(ctx context.Context, site string) ([]SiteHealth, error) {
+	var respBody struct {
+		Meta meta         `json:"meta"`
+		Data []SiteHealth `json:"data"`
+	}
+
+	err := c.do(ctx, http.MethodGet, fmt.Sprintf("api/s/%s/stat/health", site), nil, &respBody)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := respBody.Meta.error(); err != nil {
+		return nil, err
+	}
+
+	return respBody.Data, nil
+}

--- a/unifi/site_health_test.go
+++ b/unifi/site_health_test.go
@@ -1,0 +1,155 @@
+package unifi
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// siteHealthTestServer stands up a new-style (UniFi OS) controller that serves
+// the site health metrics at s/{site}/stat/health. When rawBody is non-empty
+// it is served verbatim with the given status; otherwise dataJSON is wrapped
+// in an rc:ok envelope.
+func siteHealthTestServer(t *testing.T, site, dataJSON, rawBody string, status int) *httptest.Server {
+	t.Helper()
+	healthPath := "/proxy/network/api/s/" + site + "/stat/health"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if handleNewStyleSetup(w, r) {
+			return
+		}
+		if r.Method == http.MethodPost && r.URL.Path == loginPathNew {
+			w.Header().Set("X-Csrf-Token", "tok")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.Method == http.MethodGet && r.URL.Path == healthPath {
+			w.Header().Set("Content-Type", "application/json")
+			if status != http.StatusOK {
+				w.WriteHeader(status)
+			}
+			if rawBody != "" {
+				_, _ = w.Write([]byte(rawBody))
+				return
+			}
+			if status != http.StatusOK {
+				_, _ = w.Write([]byte(`{"meta":{"rc":"error","msg":"api.err.NoSiteContext"},"data":[]}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"meta":{"rc":"ok"},"data":` + dataJSON + `}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func newSiteHealthTestClient(t *testing.T, srv *httptest.Server) *ApiClient {
+	t.Helper()
+	c, err := New(context.Background(), &Config{BaseURL: srv.URL, Username: "admin", Password: "admin"})
+	if err != nil {
+		t.Fatalf("client init: %v", err)
+	}
+	return c
+}
+
+// TestGetHealth_ParsesSubsystems verifies GetHealth returns one entry per
+// subsystem with the per-subsystem fields decoded (WAN gateway details, WLAN
+// device/user counts).
+func TestGetHealth_ParsesSubsystems(t *testing.T) {
+	const site = "default"
+	srv := siteHealthTestServer(t, site, `[
+		{"subsystem":"wan","status":"ok","wan_ip":"203.0.113.10","gw_mac":"aa:bb:cc:dd:ee:ff","gw_version":"4.4.56","latency":12,"uptime":86400,"gateways":["203.0.113.1"]},
+		{"subsystem":"wlan","status":"ok","num_ap":3,"num_adopted":3,"num_user":17,"num_guest":2},
+		{"subsystem":"vpn","status":"unknown"}
+	]`, "", http.StatusOK)
+	c := newSiteHealthTestClient(t, srv)
+
+	got, err := c.GetHealth(context.Background(), site)
+	if err != nil {
+		t.Fatalf("GetHealth errored: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3 subsystems", len(got))
+	}
+	wan := got[0]
+	if wan.Subsystem != "wan" || wan.Status != "ok" {
+		t.Errorf("wan subsystem/status = %q/%q, want wan/ok", wan.Subsystem, wan.Status)
+	}
+	if wan.WanIP != "203.0.113.10" || wan.GwMac != "aa:bb:cc:dd:ee:ff" || fmt.Sprint(wan.Latency) != "12" {
+		t.Errorf("wan details = %q/%q/%v, want 203.0.113.10/aa:bb:cc:dd:ee:ff/12", wan.WanIP, wan.GwMac, wan.Latency)
+	}
+	if len(wan.Gateways) != 1 || wan.Gateways[0] != "203.0.113.1" {
+		t.Errorf("wan gateways = %v, want [203.0.113.1]", wan.Gateways)
+	}
+	wlan := got[1]
+	if fmt.Sprint(wlan.NumAp) != "3" || fmt.Sprint(wlan.NumUser) != "17" || fmt.Sprint(wlan.NumGuest) != "2" {
+		t.Errorf("wlan counts = %v/%v/%v, want 3/17/2", wlan.NumAp, wlan.NumUser, wlan.NumGuest)
+	}
+}
+
+// TestGetHealth_Error verifies a controller error status surfaces as an error
+// rather than an empty result.
+func TestGetHealth_Error(t *testing.T) {
+	const site = "default"
+	srv := siteHealthTestServer(t, site, "", "", http.StatusBadRequest)
+	c := newSiteHealthTestClient(t, srv)
+
+	_, err := c.GetHealth(context.Background(), site)
+	if err == nil {
+		t.Fatal("expected error from rc:error response, got nil")
+	}
+}
+
+// TestGetHealth_MixedNumberRepresentations verifies that numeric health fields
+// decode whether the controller emits them as JSON numbers or as strings —
+// real controllers emit both representations across builds.
+func TestGetHealth_MixedNumberRepresentations(t *testing.T) {
+	const site = "default"
+	srv := siteHealthTestServer(t, site, `[
+		{"subsystem":"wan","status":"ok","latency":"12","xput_up":92.5,"tx_bytes-r":123456,
+		 "gw_system-stats":{"cpu":4.2,"mem":"38.9","uptime":"86400"}},
+		{"subsystem":"wlan","status":"ok","num_user":"17","num_ap":3}
+	]`, "", http.StatusOK)
+	c := newSiteHealthTestClient(t, srv)
+
+	got, err := c.GetHealth(context.Background(), site)
+	if err != nil {
+		t.Fatalf("GetHealth errored on mixed number representations: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2 subsystems", len(got))
+	}
+	wan := got[0]
+	if fmt.Sprint(wan.Latency) != "12" || fmt.Sprint(wan.XputUp) != "92.5" || fmt.Sprint(wan.TxBytesR) != "123456" {
+		t.Errorf("wan numerics = %v/%v/%v, want 12/92.5/123456", wan.Latency, wan.XputUp, wan.TxBytesR)
+	}
+	stats := wan.GwSystemStats
+	if fmt.Sprint(stats.CPU) != "4.2" || fmt.Sprint(stats.Mem) != "38.9" || fmt.Sprint(stats.Uptime) != "86400" {
+		t.Errorf("gw system stats = %v/%v/%v, want 4.2/38.9/86400", stats.CPU, stats.Mem, stats.Uptime)
+	}
+	wlan := got[1]
+	if fmt.Sprint(wlan.NumUser) != "17" || fmt.Sprint(wlan.NumAp) != "3" {
+		t.Errorf("wlan counts = %v/%v, want 17/3", wlan.NumUser, wlan.NumAp)
+	}
+}
+
+// TestGetHealth_MetaErrorWithHTTP200 verifies that an in-band controller error
+// (HTTP 200 with meta.rc "error") is surfaced instead of an empty success.
+func TestGetHealth_MetaErrorWithHTTP200(t *testing.T) {
+	const site = "default"
+	srv := siteHealthTestServer(t, site, "",
+		`{"meta":{"rc":"error","msg":"api.err.NoSiteContext"},"data":[]}`, http.StatusOK)
+	c := newSiteHealthTestClient(t, srv)
+
+	_, err := c.GetHealth(context.Background(), site)
+	if err == nil {
+		t.Fatal("expected error from HTTP 200 rc:error response, got nil")
+	}
+	if !strings.Contains(err.Error(), "api.err.NoSiteContext") {
+		t.Errorf("error = %q, want it to carry the controller message", err)
+	}
+}


### PR DESCRIPTION
## What

Adds `GetHealth(ctx, site)` returning `[]SiteHealth` from `api/s/{site}/stat/health` — per-subsystem health (wan/lan/wlan/www/vpn) with gateway system stats, ported from britannic/go-unifi and adapted to this repo's conventions:

- Numeric-ish fields use `types.Number`, matching the generated models' emulated-number handling, so both string and number JSON representations decode (controllers emit either depending on version).
- HTTP 200 with `meta.rc:"error"` surfaces as an `*APIError` instead of an empty success.

## Verification

TDD; 4 tests: multi-subsystem parse (WAN gateway details, WLAN counts), mixed number/string representations, in-band meta error, HTTP error status. `go build`, full `go test`, `gofmt`, golangci-lint v2: clean, no new issues.

One adjacent observation (pre-existing, untouched): `CreateSite`/`UpdateSite`/`DeleteSite` in `unifi/sites.go` use paths without the `api/` segment (`s/default/cmd/sitemgr`), which resolves to `/proxy/network/s/...` on new-style controllers — likely broken; happy to file a follow-up if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
