### PR TITLE
fix(port-profile): stop dropping empty native_networkconf_id (#383)

### DIFF
--- a/cmd/fields/main.go
+++ b/cmd/fields/main.go
@@ -134,6 +134,19 @@ type FieldInfo struct {
 	CustomUnmarshalFunc string
 }
 
+// clearNativeNetworkOmitEmpty keeps native_networkconf_id serialized even when
+// empty. The controller treats an explicit "" as "set the native network to
+// None", but the default codegen marks the string omitempty, so "" is dropped
+// from the body and clearing the native VLAN silently no-ops (#383). Applied to
+// PortProfile (the reported case). The same field on DevicePortOverrides is a
+// nested type that resource FieldProcessors do not reach, so it is unaffected.
+func clearNativeNetworkOmitEmpty(name string, f *FieldInfo) error {
+	if name == "NATiveNetworkID" {
+		f.OmitEmpty = false
+	}
+	return nil
+}
+
 func NewResource(structName string, resourcePath string) *ResourceInfo {
 	baseType := NewFieldInfo(structName, resourcePath, "struct", "", false, false, false, "")
 	resource := &ResourceInfo{
@@ -247,6 +260,8 @@ func NewResource(structName string, resourcePath string) *ResourceInfo {
 		baseType.Fields["Type"] = NewFieldInfo("Type", "type", fields.String, "", true, false, false, "")
 		baseType.Fields["InformIP"] = NewFieldInfo("InformIP", "inform_ip", fields.String, "", true, false, false, "")
 		baseType.Fields["IP"] = NewFieldInfo("IP", "ip", fields.String, "", true, false, false, "")
+	case resource.StructName == "PortProfile":
+		resource.FieldProcessor = clearNativeNetworkOmitEmpty
 	case resource.StructName == "Client":
 		baseType.Fields[" DisplayName"] = NewFieldInfo("DisplayName", "display_name", fields.String, "non-generated field", true, false, false, "")
 		// The controller reports the client's most recent IP on /rest/user but

--- a/unifi/port_profile.generated.go
+++ b/unifi/port_profile.generated.go
@@ -46,7 +46,7 @@ type PortProfile struct {
 	LldpmedEnabled               bool                   `json:"lldpmed_enabled"`
 	LldpmedNotifyEnabled         bool                   `json:"lldpmed_notify_enabled"`
 	MulticastRouterNetworkIDs    []string               `json:"multicast_router_networkconf_ids,omitempty"`
-	NATiveNetworkID              string                 `json:"native_networkconf_id,omitempty"`
+	NATiveNetworkID              string                 `json:"native_networkconf_id"`
 	Name                         string                 `json:"name,omitempty"`
 	OpMode                       string                 `json:"op_mode,omitempty"`  // switch
 	PoeMode                      string                 `json:"poe_mode,omitempty"` // auto|off


### PR DESCRIPTION
Fixes ubiquiti-community/terraform-provider-unifi#383.

## Context
The controller treats an explicit empty `native_networkconf_id` as "set the native network to None". But the default codegen marks `PortProfile.NATiveNetworkID` `omitempty`, so an empty string is dropped from the request body and clearing the native VLAN from a port profile silently no-ops.

## Changes
- Add a `FieldProcessor` for the `PortProfile` resource in `cmd/fields/main.go` that clears `OmitEmpty` on `NATiveNetworkID`, and regenerate.
- Result: `unifi/port_profile.generated.go` now tags the field `json:"native_networkconf_id"` (no `omitempty`), so `""` is sent.

## Scope note
The same field exists on `DevicePortOverrides` (`unifi/device.generated.go`), but that is a nested type which resource `FieldProcessor`s do not reach, so it is intentionally left unchanged here. The provider side (`unifi_port_profile`) is the case reported in #383.

## Tests
- `go build ./...`, `go test ./...` all pass. Regenerated at the pinned controller version 9.5.21 (diff is exactly the one-line tag change plus the generator rule).

https://claude.ai/code/session_01D83uMn2TM7GdYPchVt7EWV