### PR TITLE
fix(client): retry rate-limited (429) requests for API-key auth, honoring Retry-After

### DIFF
--- a/unifi/ratelimit_data_test.go
+++ b/unifi/ratelimit_data_test.go
@@ -1,0 +1,75 @@
+package unifi
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+// TestDataRequest_RateLimitedThenSucceeds proves that with API-key auth (no
+// login step at all) a controller 429 on an ordinary data request is retried
+// by the transport — honoring Retry-After — instead of failing the call. A
+// Terraform plan issues hundreds of serial reads through the cloud connector
+// proxy, and a single rate-limit hit must not abort the run.
+func TestDataRequest_RateLimitedThenSucceeds(t *testing.T) {
+	var hits int32
+	const rateLimitedAttempts = 2
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if handleNewStyleSetup(w, r) {
+			return
+		}
+		if r.URL.Path == "/proxy/network/api/s/default/rest/networkconf" {
+			if atomic.AddInt32(&hits, 1) <= rateLimitedAttempts {
+				w.Header().Set("Retry-After", "0")
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
+			_, _ = w.Write([]byte(`{"meta":{"rc":"ok"},"data":[]}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c, err := New(context.Background(), &Config{BaseURL: srv.URL, APIKey: "test-key"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if _, err := c.ListNetwork(context.Background(), "default"); err != nil {
+		t.Fatalf("ListNetwork should survive %d rate-limited attempts, got: %v", rateLimitedAttempts, err)
+	}
+	if n := atomic.LoadInt32(&hits); n != rateLimitedAttempts+1 {
+		t.Fatalf("expected %d attempts (2 rate-limited + 1 success), got %d", rateLimitedAttempts+1, n)
+	}
+}
+
+// TestDataRequest_RateLimitExhaustionSurfacesError proves a persistent 429 on a
+// data request still surfaces as a RateLimitError once the transport's retry
+// budget is spent, rather than looping forever.
+func TestDataRequest_RateLimitExhaustionSurfacesError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if handleNewStyleSetup(w, r) {
+			return
+		}
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	retryMax := 1
+	c, err := New(context.Background(), &Config{BaseURL: srv.URL, APIKey: "test-key", RetryMax: &retryMax})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	_, err = c.ListNetwork(context.Background(), "default")
+	var rle *RateLimitError
+	if !errors.As(err, &rle) {
+		t.Fatalf("expected RateLimitError after retry exhaustion, got: %v", err)
+	}
+}

--- a/unifi/unifi.go
+++ b/unifi/unifi.go
@@ -92,14 +92,38 @@ func New(ctx context.Context, cfg *Config) (*ApiClient, error) {
 		c.RetryMax = *cfg.RetryMax
 	}
 
-	// Don't let the transport silently retry HTTP 429: surface it as a
-	// RateLimitError (see doRequest) so loginWithRetry can honor Retry-After
-	// with a login-specific budget. Everything else keeps the default policy.
+	// Login 429s are surfaced as RateLimitError (see doRequest) so loginWithRetry
+	// can honor Retry-After with a login-specific budget. All other requests let
+	// the transport retry 429 itself — retryablehttp's DefaultBackoff honors
+	// Retry-After — because with API-key auth there is no login step, and a
+	// single controller rate-limit hit would otherwise fail the whole run.
 	c.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
 		if resp != nil && resp.StatusCode == http.StatusTooManyRequests {
-			return false, nil
+			if resp.Request != nil &&
+				(strings.HasSuffix(resp.Request.URL.Path, loginPath) ||
+					strings.HasSuffix(resp.Request.URL.Path, loginPathNew)) {
+				return false, nil
+			}
+			return true, nil
 		}
 		return retryablehttp.DefaultRetryPolicy(ctx, resp, err)
+	}
+
+	// When the retry budget is spent on controller rate limiting, hand the final
+	// 429 back so doRequest surfaces a typed RateLimitError (with its Retry-After
+	// hint) instead of retryablehttp's opaque "giving up" error.
+	c.ErrorHandler = func(resp *http.Response, err error, numTries int) (*http.Response, error) {
+		if resp != nil && resp.StatusCode == http.StatusTooManyRequests && err == nil {
+			return resp, nil
+		}
+		if resp != nil {
+			_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+			_ = resp.Body.Close()
+		}
+		if err == nil {
+			err = fmt.Errorf("giving up after %d attempt(s)", numTries)
+		}
+		return nil, err
 	}
 
 	if cfg.AllowInsecure {


### PR DESCRIPTION
# fix: retry rate-limited (429) requests for API-key auth, honoring Retry-After

## The regression

The login-backoff work disabled the transport's automatic HTTP 429 retry for **all** requests, so `loginWithRetry` could own the Retry-After budget:

```go
c.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
    if resp != nil && resp.StatusCode == http.StatusTooManyRequests {
        return false, nil
    }
    ...
```

For username/password users that's fine — login is where their 429s happen. But **API-key clients never log in**, so for them this turned every controller rate-limit blip into an immediate hard failure:

```
Could not read firewall policy …: rate limited by controller (retry after 5s);
consider API-key auth to avoid per-run login
```

(with API-key auth already in use — the hint is unreachable advice.) A Terraform plan through the Cloud Connector proxy issues hundreds of serial reads; a single 429 aborts the whole run. Before the login-backoff change, retryablehttp's default policy retried these quietly.

## The fix

- `CheckRetry`: 429 on the **login paths** (`/api/login`, `/api/auth/login`) keeps surfacing immediately, preserving `loginWithRetry`'s own Retry-After handling. 429 anywhere else is retried by the transport — retryablehttp's `DefaultBackoff` already honors `Retry-After` on 429.
- `ErrorHandler`: when the retry budget is exhausted on persistent 429s, hand back the final response so `doRequest` surfaces the typed `RateLimitError` (with its Retry-After hint) instead of retryablehttp's opaque `giving up after N attempt(s)`.

`Config.RetryMax` continues to bound the attempts.

## Tests

- `TestDataRequest_RateLimitedThenSucceeds` — API-key client, data endpoint returns 429, 429, 200: the call must succeed with exactly 3 attempts.
- `TestDataRequest_RateLimitExhaustionSurfacesError` — persistent 429 with `RetryMax=1`: the call must fail with a `RateLimitError`, not an untyped error.
- The existing login rate-limit suite (`TestLogin_RateLimitedThenSucceeds`, `TestLogin_ExhaustionReturnsRateLimitError`, …) passes unchanged — login behavior is untouched.

Seen in production against a UDM-Pro via the Cloud Connector proxy (`api.ui.com`), where the proxy rate-limits bursts of reads during `terraform plan`.
