### PR TITLE
fix: corporate/guest network marshaling drops dhcpd_ip_1..3 (DHCP guarding unusable, trusted servers wiped on update)

### DIFF
--- a/unifi/network_encode.go
+++ b/unifi/network_encode.go
@@ -75,6 +75,9 @@ func (n *Network) marshalCorporate() ([]byte, error) {
 		SettingPreference       *string                         `json:"setting_preference,omitempty"`
 		IGMPSnooping            bool                            `json:"igmp_snooping"`
 		DHCPguardEnabled        bool                            `json:"dhcpguard_enabled"`
+		DHCPDIP1                string                          `json:"dhcpd_ip_1"`
+		DHCPDIP2                string                          `json:"dhcpd_ip_2"`
+		DHCPDIP3                string                          `json:"dhcpd_ip_3"`
 		MdnsEnabled             bool                            `json:"mdns_enabled"`
 		LteLanEnabled           bool                            `json:"lte_lan_enabled"`
 		IPAliases               []string                        `json:"ip_aliases"`
@@ -161,6 +164,9 @@ func (n *Network) marshalCorporate() ([]byte, error) {
 		SettingPreference:       valueOrDefault(n.SettingPreference, "auto"),
 		IGMPSnooping:            n.IGMPSnooping,
 		DHCPguardEnabled:        n.DHCPguardEnabled,
+		DHCPDIP1:                n.DHCPDIP1,
+		DHCPDIP2:                n.DHCPDIP2,
+		DHCPDIP3:                n.DHCPDIP3,
 		MdnsEnabled:             n.MdnsEnabled,
 		LteLanEnabled:           n.LteLanEnabled,
 		IPAliases:               orEmptySlice(n.IPAliases),
@@ -313,6 +319,9 @@ func (n *Network) marshalGuest() ([]byte, error) {
 		SettingPreference       *string                         `json:"setting_preference,omitempty"`
 		IGMPSnooping            bool                            `json:"igmp_snooping"`
 		DHCPguardEnabled        bool                            `json:"dhcpguard_enabled"`
+		DHCPDIP1                string                          `json:"dhcpd_ip_1"`
+		DHCPDIP2                string                          `json:"dhcpd_ip_2"`
+		DHCPDIP3                string                          `json:"dhcpd_ip_3"`
 		MdnsEnabled             bool                            `json:"mdns_enabled"`
 		LteLanEnabled           bool                            `json:"lte_lan_enabled"`
 		IPAliases               []string                        `json:"ip_aliases"`
@@ -399,6 +408,9 @@ func (n *Network) marshalGuest() ([]byte, error) {
 		SettingPreference:       valueOrDefault(n.SettingPreference, "auto"),
 		IGMPSnooping:            n.IGMPSnooping,
 		DHCPguardEnabled:        n.DHCPguardEnabled,
+		DHCPDIP1:                n.DHCPDIP1,
+		DHCPDIP2:                n.DHCPDIP2,
+		DHCPDIP3:                n.DHCPDIP3,
 		MdnsEnabled:             n.MdnsEnabled,
 		LteLanEnabled:           n.LteLanEnabled,
 		IPAliases:               orEmptySlice(n.IPAliases),

--- a/unifi/network_encode_test.go
+++ b/unifi/network_encode_test.go
@@ -526,3 +526,47 @@ func TestMarshalNetworkSiteVPN(t *testing.T) {
 func strPtr(s string) *string {
 	return &s
 }
+
+// Corporate and guest networks previously emitted dhcpguard_enabled without
+// dhcpd_ip_1..3, so enabling DHCP guarding failed with api.err.MissingIPAddress
+// and any update cleared the trusted servers on the controller. VLAN-only
+// networks already carried the fields.
+func TestMarshalNetworkDHCPGuarding(t *testing.T) {
+	for _, purpose := range []string{PurposeCorporate, PurposeGuest} {
+		t.Run(purpose, func(t *testing.T) {
+			network := &Network{
+				ID:               "507f1f77bcf86cd799439011",
+				Name:             strPtr("Guarded"),
+				Purpose:          purpose,
+				IPSubnet:         strPtr("192.168.1.0/24"),
+				DHCPguardEnabled: true,
+				DHCPDIP1:         "192.168.1.1",
+				DHCPDIP2:         "192.168.1.2",
+			}
+
+			data, err := json.Marshal(network)
+			if err != nil {
+				t.Fatalf("Failed to marshal network: %v", err)
+			}
+
+			checkJSONFields(
+				t,
+				data,
+				[]string{"dhcpguard_enabled", "dhcpd_ip_1", "dhcpd_ip_2", "dhcpd_ip_3"},
+				nil,
+			)
+
+			var result map[string]any
+			json.Unmarshal(data, &result)
+			if result["dhcpguard_enabled"] != true {
+				t.Errorf("Expected dhcpguard_enabled true, got %v", result["dhcpguard_enabled"])
+			}
+			if result["dhcpd_ip_1"] != "192.168.1.1" {
+				t.Errorf("Expected dhcpd_ip_1 '192.168.1.1', got %v", result["dhcpd_ip_1"])
+			}
+			if result["dhcpd_ip_2"] != "192.168.1.2" {
+				t.Errorf("Expected dhcpd_ip_2 '192.168.1.2', got %v", result["dhcpd_ip_2"])
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Enabling DHCP guarding on a corporate or guest network through this client fails with **`api.err.MissingIPAddress`**, and any update to a corporate or guest network that has guarding configured on the controller **silently clears its trusted DHCP servers**.

Cause: `marshalCorporate` and `marshalGuest` emit `dhcpguard_enabled` but omit `dhcpd_ip_1..3`. Fix: add the three fields to both paths, matching `marshalVLANOnly` — 12 insertions, field selection only, plus a test.

## Root cause

`Network.MarshalJSON` marshals per-purpose field sets. `marshalCorporate` and `marshalGuest` include `dhcpguard_enabled` but omit `dhcpd_ip_1`, `dhcpd_ip_2`, `dhcpd_ip_3` entirely, so:

- Setting `DHCPguardEnabled: true` with `DHCPDIP1` populated sends `dhcpguard_enabled: true` with no trusted-server field → the controller rejects the write with `api.err.MissingIPAddress`.
- Updating any other field on a network that has guarding configured on the controller sends a body without the `dhcpd_ip_*` keys → the controller drops the stored trusted servers.

`marshalVLANOnly` already carries all four fields; the WAN path correctly has none of them.

Observed against a UniFi OS gateway on Network 10.5.67 (via terraform-provider-unifi v0.55.0, which builds its PUT body through this marshaler). Confirmed the controller accepts `dhcpguard_enabled` + `dhcpd_ip_1` on the same endpoint when sent directly.

## Fix

Add `DHCPDIP1..3` (`dhcpd_ip_1..3`) to the field selection in `marshalCorporate` and `marshalGuest`, matching `marshalVLANOnly`. Bare `string` fields (no `omitempty`), same as the VLAN-only path — the controller's field regex explicitly allows the empty string.

## Tests

- New `TestMarshalNetworkDHCPGuarding` (corporate + guest subtests): asserts the marshaled JSON contains `dhcpguard_enabled` and all three `dhcpd_ip_*` keys with the configured values.
- Full package suite passes: `go test ./unifi/` → ok; `go vet` clean.