### PR TITLE
fix: corporate networks send remote_vpn_subnets as dhcp_relay_servers, dropping configured relay servers

### DIFF
--- a/unifi/network_encode.go
+++ b/unifi/network_encode.go
@@ -202,7 +202,7 @@ func (n *Network) marshalCorporate() ([]byte, error) {
 
 		// DHCP Relay
 		DHCPRelayEnabled: n.DHCPRelayEnabled,
-		DHCPRelayServers: orEmptySlice(n.RemoteVPNSubnets),
+		DHCPRelayServers: orEmptySlice(n.DHCPRelayServers),
 
 		// IPv6
 		IPV6InterfaceType:           valueOrDefault(n.IPV6InterfaceType, "none"),

--- a/unifi/network_encode_test.go
+++ b/unifi/network_encode_test.go
@@ -570,3 +570,41 @@ func TestMarshalNetworkDHCPGuarding(t *testing.T) {
 		})
 	}
 }
+
+// marshalCorporate previously populated dhcp_relay_servers from
+// RemoteVPNSubnets, so configured relay servers never reached the controller
+// and remote VPN subnets leaked into the field. The guest path was correct.
+func TestMarshalNetworkDHCPRelayServers(t *testing.T) {
+	for _, purpose := range []string{PurposeCorporate, PurposeGuest} {
+		t.Run(purpose, func(t *testing.T) {
+			network := &Network{
+				ID:               "507f1f77bcf86cd799439011",
+				Name:             strPtr("Relayed"),
+				Purpose:          purpose,
+				IPSubnet:         strPtr("192.168.1.0/24"),
+				DHCPRelayEnabled: true,
+				DHCPRelayServers: []string{"192.168.1.5", "192.168.1.6"},
+				RemoteVPNSubnets: []string{"10.0.0.0/24"},
+			}
+
+			data, err := json.Marshal(network)
+			if err != nil {
+				t.Fatalf("Failed to marshal network: %v", err)
+			}
+
+			var result map[string]any
+			json.Unmarshal(data, &result)
+
+			servers, ok := result["dhcp_relay_servers"].([]any)
+			if !ok {
+				t.Fatalf(
+					"Expected dhcp_relay_servers to be a list, got %T",
+					result["dhcp_relay_servers"],
+				)
+			}
+			if len(servers) != 2 || servers[0] != "192.168.1.5" || servers[1] != "192.168.1.6" {
+				t.Errorf("Expected dhcp_relay_servers [192.168.1.5 192.168.1.6], got %v", servers)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`marshalCorporate` populates the `dhcp_relay_servers` JSON key from `n.RemoteVPNSubnets` instead of `n.DHCPRelayServers`. One-word fix plus a regression test.

## Why this is a bug and not intent (verified, not assumed)

- **Provenance:** the line was born mismatched in a3d3a80 ("feat: Added improved nullability handling"), which introduced the whole hand-written DHCP-relay block — it was never changed *to* `RemoteVPNSubnets` deliberately. The guest path from the same authoring uses `n.DHCPRelayServers`.
- **Encode/decode asymmetry:** the generated `UnmarshalJSON` maps `dhcp_relay_servers` → `DHCPRelayServers`. Encoding the same JSON key from a different struct field means a plain GET→PUT round-trip of a corporate network mutates data by construction: relay servers read into `DHCPRelayServers` are dropped on write, and since `remote_vpn_subnets` never appears on corporate reads, every corporate PUT sends `dhcp_relay_servers: []` — clearing anything configured in the UI.
- **The spec treats them as distinct fields:** the generator wires `DHCPRelayServers` ← `dhcp_relay_servers` (`cmd/fields/main.go:251`), and `remote_vpn_subnets` is a site-vpn field with CIDR validation. A live controller (Network 10.5.67) shows corporate networks natively carry `dhcp_relay_servers`; `remote_vpn_subnets` does not exist on them.
- **Downstream already treats it as a defect:** terraform-provider-unifi carries an explicit workaround — it sets *both* struct fields, with a comment naming this exact mismatch ([network_resource.go](https://github.com/ubiquiti-community/terraform-provider-unifi/blob/main/unifi/network_resource.go#L1608-L1614)). This fix is compatible with that workaround (both fields hold the same value, so the wire output is unchanged), and makes it removable.

## Consequences before the fix

- Any consumer following the struct contract (setting `DHCPRelayServers` on a corporate network) has the value silently dropped.
- Read-modify-write round-trips clear relay servers configured outside the client.
- Setting `RemoteVPNSubnets` on a corporate network leaks it into `dhcp_relay_servers` on the wire (the mechanism the provider workaround deliberately exploits).

## Fix

`n.RemoteVPNSubnets` → `n.DHCPRelayServers` in `marshalCorporate`.

## Tests

- New `TestMarshalNetworkDHCPRelayServers` (corporate + guest subtests): marshals a network with both `DHCPRelayServers` and a decoy `RemoteVPNSubnets` set, and asserts `dhcp_relay_servers` carries exactly the relay servers.
- Full package suite passes: `go test ./unifi/` → ok; `go vet` clean.