### PR TITLE
feat(wlan): add BandsteeringMode to the WLAN model

### DIFF
--- a/unifi/wlan.generated.go
+++ b/unifi/wlan.generated.go
@@ -37,6 +37,7 @@ type WLAN struct {
 	ApGroupMode                 string                     `json:"ap_group_mode,omitempty"` // all|groups|devices
 	AuthCache                   bool                       `json:"auth_cache"`
 	BSupported                  bool                       `json:"b_supported"`
+	BandsteeringMode            string                     `json:"bandsteering_mode,omitempty"` // off|equal|prefer_5g
 	BroadcastFilterEnabled      bool                       `json:"bc_filter_enabled"`
 	BroadcastFilterList         []string                   `json:"bc_filter_list,omitempty"` // ^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$
 	BssTransition               bool                       `json:"bss_transition"`


### PR DESCRIPTION
Modern controllers (Network 9/10.x) expose per-SSID band steering as `bandsteering_mode` on the wlanconf record (`off|equal|prefer_5g`). On WiFi 6/7 APs this per-SSID control has replaced the legacy device-level one — which the `Device` model already carries — so without a WLAN field the SDK silently drops the value on read and cannot write it, leaving band steering unmanageable on current hardware.

Needed by ubiquiti-community/terraform-provider-unifi#388.

One-line addition mirroring `Device.BandsteeringMode`, following the existing precedent of surgical fixes to generated models (e.g. "Omit empty WLAN group ID"); a future regeneration from a 10.x fields JAR will carry the field natively.

- `go build ./...` and `go test ./unifi/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)