### PR TITLE
fix: corporate/guest network marshaling cannot clear dhcpd_dns_1..4 / dhcpd_ntp_1..2

### DIFF
--- a/unifi/network_encode.go
+++ b/unifi/network_encode.go
@@ -90,10 +90,10 @@ func (n *Network) marshalCorporate() ([]byte, error) {
 		DHCPDStop              *string `json:"dhcpd_stop,omitempty"`
 		DHCPDLeaseTime         *int64  `json:"dhcpd_leasetime,omitempty"`
 		DHCPDDNSEnabled        bool    `json:"dhcpd_dns_enabled"`
-		DHCPDDNS1              string  `json:"dhcpd_dns_1,omitempty"`
-		DHCPDDNS2              string  `json:"dhcpd_dns_2,omitempty"`
-		DHCPDDNS3              string  `json:"dhcpd_dns_3,omitempty"`
-		DHCPDDNS4              string  `json:"dhcpd_dns_4,omitempty"`
+		DHCPDDNS1              string  `json:"dhcpd_dns_1"`
+		DHCPDDNS2              string  `json:"dhcpd_dns_2"`
+		DHCPDDNS3              string  `json:"dhcpd_dns_3"`
+		DHCPDDNS4              string  `json:"dhcpd_dns_4"`
 		DHCPDGatewayEnabled    bool    `json:"dhcpd_gateway_enabled"`
 		DHCPDGateway           *string `json:"dhcpd_gateway,omitempty"`
 		DHCPDNtpEnabled        bool    `json:"dhcpd_ntp_enabled"`
@@ -186,8 +186,8 @@ func (n *Network) marshalCorporate() ([]byte, error) {
 		DHCPDGatewayEnabled:    n.DHCPDGatewayEnabled,
 		DHCPDGateway:           n.DHCPDGateway,
 		DHCPDNtpEnabled:        n.DHCPDNtpEnabled,
-		DHCPDNtp1:              nilIfEmpty(n.DHCPDNtp1),
-		DHCPDNtp2:              nilIfEmpty(n.DHCPDNtp2),
+		DHCPDNtp1:              n.DHCPDNtp1,
+		DHCPDNtp2:              n.DHCPDNtp2,
 		DHCPDWinsEnabled:       n.DHCPDWinsEnabled,
 		DHCPDWins1:             valueOrDefault(n.DHCPDWins1, ""),
 		DHCPDWins2:             valueOrDefault(n.DHCPDWins2, ""),
@@ -334,10 +334,10 @@ func (n *Network) marshalGuest() ([]byte, error) {
 		DHCPDStop              *string `json:"dhcpd_stop,omitempty"`
 		DHCPDLeaseTime         *int64  `json:"dhcpd_leasetime,omitempty"`
 		DHCPDDNSEnabled        bool    `json:"dhcpd_dns_enabled"`
-		DHCPDDNS1              string  `json:"dhcpd_dns_1,omitempty"`
-		DHCPDDNS2              string  `json:"dhcpd_dns_2,omitempty"`
-		DHCPDDNS3              string  `json:"dhcpd_dns_3,omitempty"`
-		DHCPDDNS4              string  `json:"dhcpd_dns_4,omitempty"`
+		DHCPDDNS1              string  `json:"dhcpd_dns_1"`
+		DHCPDDNS2              string  `json:"dhcpd_dns_2"`
+		DHCPDDNS3              string  `json:"dhcpd_dns_3"`
+		DHCPDDNS4              string  `json:"dhcpd_dns_4"`
 		DHCPDGatewayEnabled    bool    `json:"dhcpd_gateway_enabled"`
 		DHCPDGateway           *string `json:"dhcpd_gateway,omitempty"`
 		DHCPDNtpEnabled        bool    `json:"dhcpd_ntp_enabled"`
@@ -430,8 +430,8 @@ func (n *Network) marshalGuest() ([]byte, error) {
 		DHCPDGatewayEnabled:    n.DHCPDGatewayEnabled,
 		DHCPDGateway:           n.DHCPDGateway,
 		DHCPDNtpEnabled:        n.DHCPDNtpEnabled,
-		DHCPDNtp1:              nilIfEmpty(n.DHCPDNtp1),
-		DHCPDNtp2:              nilIfEmpty(n.DHCPDNtp2),
+		DHCPDNtp1:              n.DHCPDNtp1,
+		DHCPDNtp2:              n.DHCPDNtp2,
 		DHCPDWinsEnabled:       n.DHCPDWinsEnabled,
 		DHCPDWins1:             valueOrDefault(n.DHCPDWins1, ""),
 		DHCPDWins2:             valueOrDefault(n.DHCPDWins2, ""),
@@ -917,13 +917,6 @@ func orEmptyWANDHCPOptions(s []NetworkWANDHCPOptions) []NetworkWANDHCPOptions {
 		return s
 	}
 	return []NetworkWANDHCPOptions{}
-}
-
-func nilIfEmpty(s *string) *string {
-	if s != nil && *s == "" {
-		return nil
-	}
-	return s
 }
 
 func derefOrEmpty(s *string) string {

--- a/unifi/network_encode_test.go
+++ b/unifi/network_encode_test.go
@@ -608,3 +608,55 @@ func TestMarshalNetworkDHCPRelayServers(t *testing.T) {
 		})
 	}
 }
+
+// marshalCorporate/marshalGuest previously tagged dhcpd_dns_1..4 with
+// omitempty and squashed a pointer-to-"" dhcpd_ntp_1/2 to nil (nilIfEmpty),
+// so an explicit clear ("" values) was dropped from the request body. The
+// controller's networkconf PUT keeps omitted fields, so DNS/NTP servers could
+// be set but never unset (terraform-provider-unifi#429). Empty DNS slots must
+// serialize as "" and a pointer-to-"" NTP slot must survive; a nil NTP slot
+// stays omitted so plain reads/writes don't clear controller state.
+func TestMarshalNetworkDNSNtpClear(t *testing.T) {
+	for _, purpose := range []string{PurposeCorporate, PurposeGuest} {
+		t.Run(purpose, func(t *testing.T) {
+			emptyNtp := ""
+			network := &Network{
+				ID:        "507f1f77bcf86cd799439011",
+				Name:      strPtr("Clearing"),
+				Purpose:   purpose,
+				IPSubnet:  strPtr("192.168.1.0/24"),
+				DHCPDDNS1: "",
+				DHCPDDNS2: "",
+				DHCPDDNS3: "",
+				DHCPDDNS4: "",
+				DHCPDNtp1: &emptyNtp,
+				DHCPDNtp2: nil,
+			}
+
+			data, err := json.Marshal(network)
+			if err != nil {
+				t.Fatalf("Failed to marshal network: %v", err)
+			}
+
+			checkJSONFields(
+				t,
+				data,
+				[]string{
+					"dhcpd_dns_1", "dhcpd_dns_2", "dhcpd_dns_3", "dhcpd_dns_4",
+					"dhcpd_ntp_1",
+				},
+				[]string{"dhcpd_ntp_2"},
+			)
+
+			var result map[string]any
+			if err := json.Unmarshal(data, &result); err != nil {
+				t.Fatalf("Failed to unmarshal JSON: %v", err)
+			}
+			for _, f := range []string{"dhcpd_dns_1", "dhcpd_dns_2", "dhcpd_dns_3", "dhcpd_dns_4", "dhcpd_ntp_1"} {
+				if result[f] != "" {
+					t.Errorf("Expected %s to be an empty string, got %v", f, result[f])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`marshalCorporate` and `marshalGuest` tag `dhcpd_dns_1..4` with `omitempty` and squash a pointer-to-`""` `dhcpd_ntp_1/2` to `nil` via `nilIfEmpty`, so an explicit clear (empty values) is silently dropped from the request body. The controller's `networkconf` PUT keeps omitted fields, so DNS/NTP servers can be set through this client but never unset — surfacing downstream as ubiquiti-community/terraform-provider-unifi#429 ("dns_servers cannot be set to empty"). Verified against a live demo controller: a PUT omitting `dhcpd_dns_1` leaves the old value in place.

## Changes

- `dhcpd_dns_1..4` now serialize unconditionally for corporate/guest, mirroring the `dhcpd_ip_1..3` fix (#68 family): `""` clears the slot.
- `dhcpd_ntp_1..2` pass the pointer through unchanged: `nil` stays omitted (controller state untouched), pointer-to-`""` serializes and clears.
- `nilIfEmpty` is unused after this and removed.
- Regression test `TestMarshalNetworkDNSNtpClear` covers both purposes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)