### PR TITLE
fix: add missing api/ prefix to sitemgr and firewall cmd endpoints

### DIFF
--- a/unifi/cmd_endpoint_path_test.go
+++ b/unifi/cmd_endpoint_path_test.go
@@ -1,0 +1,102 @@
+package unifi
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// cmdPathTestServer stands up a new-style (UniFi OS) controller that records the
+// path of the first cmd request it sees and answers it with an empty success
+// body. Everything else answers 200 so client setup completes.
+func cmdPathTestServer(t *testing.T, got *string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if handleNewStyleSetup(w, r) {
+			return
+		}
+		if r.Method == http.MethodPost && r.URL.Path == loginPathNew {
+			w.Header().Set("X-Csrf-Token", "tok")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.Method == http.MethodPost && *got == "" {
+			*got = r.URL.Path
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"meta":{"rc":"ok"},"data":[]}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func newCmdPathTestClient(t *testing.T, srv *httptest.Server) *ApiClient {
+	t.Helper()
+	c, err := New(context.Background(), &Config{BaseURL: srv.URL, Username: "admin", Password: "admin"})
+	if err != nil {
+		t.Fatalf("client init: %v", err)
+	}
+	return c
+}
+
+// The cmd endpoints live under the API root like every other call, so their
+// relative paths must carry the `api/` segment themselves: apiPath supplies only
+// the deployment prefix, which is "/proxy/network" on UniFi OS and "/" on a
+// classic controller.
+func TestCmdEndpointsCarryAPIPrefix(t *testing.T) {
+	const site = "default"
+
+	tests := []struct {
+		name string
+		want string
+		call func(*ApiClient) error
+	}{
+		{
+			name: "CreateSite",
+			want: "/proxy/network/api/s/default/cmd/sitemgr",
+			call: func(c *ApiClient) error {
+				_, err := c.CreateSite(context.Background(), "a description")
+				return err
+			},
+		},
+		{
+			name: "DeleteSite",
+			want: "/proxy/network/api/s/default/cmd/sitemgr",
+			call: func(c *ApiClient) error {
+				_, err := c.DeleteSite(context.Background(), "abcdef0123456789abcdef01")
+				return err
+			},
+		},
+		{
+			name: "UpdateSite",
+			want: "/proxy/network/api/s/" + site + "/cmd/sitemgr",
+			call: func(c *ApiClient) error {
+				_, err := c.UpdateSite(context.Background(), site, "a new description")
+				return err
+			},
+		},
+		{
+			name: "ReorderFirewallRules",
+			want: "/proxy/network/api/s/" + site + "/cmd/firewall",
+			call: func(c *ApiClient) error {
+				return c.ReorderFirewallRules(context.Background(), site, "WAN_IN", nil)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var got string
+			srv := cmdPathTestServer(t, &got)
+			c := newCmdPathTestClient(t, srv)
+
+			if err := tc.call(c); err != nil {
+				t.Fatalf("%s: %v", tc.name, err)
+			}
+			if got != tc.want {
+				t.Errorf("%s requested %q, want %q", tc.name, got, tc.want)
+			}
+		})
+	}
+}

--- a/unifi/firewall_rule.go
+++ b/unifi/firewall_rule.go
@@ -53,7 +53,7 @@ func (c *ApiClient) ReorderFirewallRules(
 		Ruleset: ruleset,
 		Rules:   reorder,
 	}
-	err := c.do(ctx, http.MethodPost, fmt.Sprintf("s/%s/cmd/firewall", site), reqBody, nil)
+	err := c.do(ctx, http.MethodPost, fmt.Sprintf("api/s/%s/cmd/firewall", site), reqBody, nil)
 	if err != nil {
 		return err
 	}

--- a/unifi/sites.go
+++ b/unifi/sites.go
@@ -86,7 +86,7 @@ func (c *ApiClient) CreateSite(ctx context.Context, description string) ([]Site,
 		Data []Site `json:"data"`
 	}
 
-	err := c.do(ctx, http.MethodPost, "s/default/cmd/sitemgr", reqBody, &respBody)
+	err := c.do(ctx, http.MethodPost, "api/s/default/cmd/sitemgr", reqBody, &respBody)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func (c *ApiClient) DeleteSite(ctx context.Context, id string) ([]Site, error) {
 		Data []Site `json:"data"`
 	}
 
-	err := c.do(ctx, http.MethodPost, "s/default/cmd/sitemgr", reqBody, &respBody)
+	err := c.do(ctx, http.MethodPost, "api/s/default/cmd/sitemgr", reqBody, &respBody)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +130,7 @@ func (c *ApiClient) UpdateSite(ctx context.Context, name, description string) ([
 		Data []Site `json:"data"`
 	}
 
-	err := c.do(ctx, http.MethodPost, fmt.Sprintf("s/%s/cmd/sitemgr", name), reqBody, &respBody)
+	err := c.do(ctx, http.MethodPost, fmt.Sprintf("api/s/%s/cmd/sitemgr", name), reqBody, &respBody)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

Four functions build their request path without the `api/` prefix that every other call in the library carries:

| Function | File | Path sent | Path expected |
| --- | --- | --- | --- |
| `CreateSite` | `unifi/sites.go` | `s/default/cmd/sitemgr` | `api/s/default/cmd/sitemgr` |
| `DeleteSite` | `unifi/sites.go` | `s/default/cmd/sitemgr` | `api/s/default/cmd/sitemgr` |
| `UpdateSite` | `unifi/sites.go` | `s/<name>/cmd/sitemgr` | `api/s/<name>/cmd/sitemgr` |
| `ReorderFirewallRules` | `unifi/firewall_rule.go` | `s/<site>/cmd/firewall` | `api/s/<site>/cmd/firewall` |

The client's base path is `proxy/network` on UniFi OS and `/` on a classic controller, and it is never
`api/`. Every relative path therefore has to carry `api/` itself, which is what the rest of the library
does.

Surfaced through `terraform-provider-unifi`, renaming a site fails with `Error Updating Site` followed by
a not-found response, and there is no way to rename a site through the provider at all:
```text
Error: Error Updating Site

Could not update site with ID <site-id>: not found:
type=*struct { Meta unifi.meta "json:\"meta\""; Data []unifi.Site "json:\"data\"" }v
```
The id in the message is correct: the same site is returned by `GET api/self/sites` with that `_id`.

## Change

Each of the four paths gains the prefix. No other behaviour changes.

## Test

`unifi/cmd_endpoint_path_test.go` starts an `httptest` server, records the path of the first POST each
function issues, and asserts all four. It fails on unfixed source in all four cases and passes with the
change:

```text
--- PASS: TestCmdEndpointsCarryAPIPrefix/CreateSite
--- PASS: TestCmdEndpointsCarryAPIPrefix/DeleteSite
--- PASS: TestCmdEndpointsCarryAPIPrefix/UpdateSite
--- PASS: TestCmdEndpointsCarryAPIPrefix/ReorderFirewallRules
```

`go build ./...` and the package test suite are both clean.

## Environment where the defect was found

| Component | Detail |
| --- | --- |
| Provider | terraform-provider-unifi 0.55.0 |
| OpenTofu | 1.12.6 |
| UniFi Network | 10.5.67 (`atag_10.5.67_35187`) |
| Hardware | UDM Pro, UniFi OS 5.1.31 |
| Connection | Cloud Connector (`api.ui.com`) |
